### PR TITLE
fix(l10n): revise Portuguese (Portugal) translation

### DIFF
--- a/MC1/Resources/Localization/pt.lproj/Chats.strings
+++ b/MC1/Resources/Localization/pt.lproj/Chats.strings
@@ -9,7 +9,7 @@
 // MARK: - Navigation & Titles
 
 /* Location: ChatsView.swift - Navigation title for main chat list */
-"chats.title" = "Chats";
+"chats.title" = "Conversas";
 
 /* Location: ChatsView.swift - Search placeholder */
 "chats.search.placeholder" = "Pesquisar conversas";
@@ -27,7 +27,7 @@
 "chats.filter.unread" = "Por ler";
 
 /* Location: ChatsView.swift - Filter option for direct messages */
-"chats.filter.directMessages" = "DMs";
+"chats.filter.directMessages" = "Mensagens diretas";
 
 /* Location: ChatsView.swift - Filter option for channels */
 "chats.filter.channels" = "Canais";
@@ -38,7 +38,7 @@
 // MARK: - Compose Menu
 
 /* Location: ChatsView.swift - Button to start a new direct chat */
-"chats.compose.newChat" = "Novo chat";
+"chats.compose.newChat" = "Nova conversa";
 
 /* Location: ChatsView.swift - Button to create or join a channel */
 "chats.compose.newChannel" = "Novo canal";
@@ -52,7 +52,7 @@
 "chats.emptyState.noConversations.title" = "Nenhuma conversa";
 
 /* Location: ChatsView.swift - Description when no conversations exist */
-"chats.emptyState.noConversations.description" = "Inicie uma conversa a partir de Contactos";
+"chats.emptyState.noConversations.description" = "Inicie uma conversa a partir do separador Nós";
 
 /* Location: ChatsView.swift - Title when no unread messages */
 "chats.emptyState.noUnread.title" = "Sem mensagens por ler";
@@ -61,22 +61,22 @@
 "chats.emptyState.noUnread.description" = "Tudo lido";
 
 /* Location: ChatsView.swift - Title when no direct messages */
-"chats.emptyState.noDirectMessages.title" = "Sem DMs";
+"chats.emptyState.noDirectMessages.title" = "Sem mensagens diretas";
 
 /* Location: ChatsView.swift - Description when no direct messages */
-"chats.emptyState.noDirectMessages.description" = "Inicie um chat a partir de Contactos";
+"chats.emptyState.noDirectMessages.description" = "Inicie uma conversa a partir do separador Nós";
 
 /* Location: ChatsView.swift - Title when no channels */
 "chats.emptyState.noChannels.title" = "Nenhum canal";
 
 /* Location: ChatsView.swift - Description when no channels */
-"chats.emptyState.noChannels.description" = "Aderir ou criar um canal";
+"chats.emptyState.noChannels.description" = "Adira ou crie um canal";
 
 /* Location: ChatsView.swift - Title when no rooms exist */
 "chats.emptyState.noRooms.title" = "Nenhuma sala";
 
 /* Location: ChatsView.swift - Description when no rooms exist */
-"chats.emptyState.noRooms.description" = "Entre numa sala a partir de Contactos";
+"chats.emptyState.noRooms.description" = "Entre numa sala a partir do separador Nós";
 
 /* Location: ChatsView.swift - Split view placeholder when no conversation selected */
 "chats.emptyState.selectConversation" = "Selecione uma conversa";
@@ -123,7 +123,7 @@
 "chats.alert.unableToSend.message" = "Certifique-se de que há uma ligação ao dispositivo e tente novamente.";
 
 /* Location: ChatConversationView.swift - Connection status for flood routed contacts */
-"chats.connectionStatus.floodRouting" = "Encaminhamento Flood";
+"chats.connectionStatus.floodRouting" = "Encaminhamento por difusão";
 
 /* Location: ChatConversationView.swift - Connection status format for direct path - %d is hop count */
 "chats.connectionStatus.direct" = "Direto • %d saltos";
@@ -141,7 +141,7 @@
 "chats.contactInfo.hasLocation" = "Tem localização";
 
 /* Location: ChatConversationView.swift - Input bar placeholder for direct messages */
-"chats.input.placeholder.directMessage" = "DM";
+"chats.input.placeholder.directMessage" = "Mensagem direta";
 
 // MARK: - Channel Chat View
 
@@ -187,7 +187,7 @@
 /* Location: ChannelInfoSheet.swift - Label for channel slot */
 /* Location: ChannelInfoSheet.swift - Label for last message date */
 /* Location: ChannelInfoSheet.swift - QR code instruction text */
-"chats.channelInfo.scanToJoin" = "Digitalize para aderir a este canal";
+"chats.channelInfo.scanToJoin" = "Leia o código QR para aderir a este canal";
 
 /* Location: ChannelInfoSheet.swift - Section header for QR sharing */
 "chats.channelInfo.shareChannel" = "Partilhar canal";
@@ -264,10 +264,10 @@
 "chats.channelOptions.joinPrivate.description" = "Introduza o nome do canal e a chave secreta";
 
 /* Location: ChannelOptionsSheet.swift - Scan QR code option title */
-"chats.channelOptions.scanQR.title" = "Digitalizar um código QR";
+"chats.channelOptions.scanQR.title" = "Ler um código QR";
 
 /* Location: ChannelOptionsSheet.swift - Scan QR code option description */
-"chats.channelOptions.scanQR.description" = "Aderir a um canal ao digitalizar o código QR";
+"chats.channelOptions.scanQR.description" = "Aderir a um canal lendo o código QR";
 
 /* Location: ChannelOptionsSheet.swift - Section header for private channels */
 "chats.channelOptions.section.private" = "Canais privados";
@@ -302,7 +302,7 @@
 "chats.newChat.emptyState.description" = "Os contactos aparecem quando forem descobertos";
 
 /* Location: NewChatView.swift - Navigation title */
-"chats.newChat.title" = "Novo chat";
+"chats.newChat.title" = "Nova conversa";
 
 /* Location: NewChatView.swift - Search placeholder */
 "chats.newChat.search.placeholder" = "Pesquisar contactos";
@@ -480,7 +480,7 @@
 "chats.joinHashtag.section.header" = "Canal hashtag";
 
 /* Location: JoinHashtagChannelView.swift - Footer explaining hashtag channels */
-"chats.joinHashtag.footer" = "Os canais hashtag são públicos. Qualquer pessoa pode aderir ao introduzir o mesmo nome. Só são permitidas letras minúsculas, números e hífenes.";
+"chats.joinHashtag.footer" = "Os canais hashtag são públicos. Qualquer pessoa pode aderir introduzindo o mesmo nome. Só são permitidas letras minúsculas, números e hífenes.";
 
 /* Location: JoinHashtagChannelView.swift - Description about encryption */
 "chats.joinHashtag.encryptionDescription" = "O nome do canal é usado para gerar a chave de encriptação. Qualquer pessoa com o mesmo nome pode ler as mensagens.";
@@ -501,7 +501,7 @@
 "chats.joinHashtag.alreadyJoined" = "Já aderiu";
 
 /* Location: JoinHashtagChannelView.swift - Accessibility label for already joined */
-"chats.joinHashtag.alreadyJoinedAccessibility" = "Canal já aderido";
+"chats.joinHashtag.alreadyJoinedAccessibility" = "Já aderiu a este canal";
 
 /* Location: JoinHashtagChannelView.swift - Navigation title */
 "chats.joinHashtag.title" = "Aderir a canal hashtag";
@@ -527,7 +527,7 @@
 "chats.joinFromMessage.noSlots.description" = "Todos os slots de canal estão cheios. Remova um canal existente para aderir a %@.";
 
 /* Location: JoinHashtagFromMessageView.swift - Description of hashtag channels */
-"chats.joinFromMessage.description" = "Os canais hashtag são públicos. Qualquer pessoa pode aderir ao introduzir o mesmo nome.";
+"chats.joinFromMessage.description" = "Os canais hashtag são públicos. Qualquer pessoa pode aderir introduzindo o mesmo nome.";
 
 /* Location: JoinHashtagFromMessageView.swift - Button to join channel - %@ is channel name */
 "chats.joinFromMessage.joinButton" = "Aderir a %@";
@@ -550,25 +550,25 @@
 // MARK: - Scan Channel QR View
 
 /* Location: ScanChannelQRView.swift - Navigation title */
-"chats.scanQR.title" = "Digitalizar código QR";
+"chats.scanQR.title" = "Ler código QR";
 
 /* Location: ScanChannelQRView.swift - Error when scanner not available */
 "chats.scanQR.notAvailable.title" = "Scanner indisponível";
 
 /* Location: ScanChannelQRView.swift - Error description when scanner not available */
-"chats.scanQR.notAvailable.description" = "A digitalização de QR não é suportada neste dispositivo";
+"chats.scanQR.notAvailable.description" = "A leitura de códigos QR não é suportada neste dispositivo";
 
 /* Location: ScanChannelQRView.swift - Instruction to point camera */
 "chats.scanQR.instruction" = "Aponte a câmara para o código QR de um canal";
 
 /* Location: ScanChannelQRView.swift - Button to scan again */
-"chats.scanQR.scanAgain" = "Digitalizar novamente";
+"chats.scanQR.scanAgain" = "Ler novamente";
 
 /* Location: ScanChannelQRView.swift - Camera permission denied title */
 "chats.scanQR.permissionDenied.title" = "É necessário acesso à câmara";
 
 /* Location: ScanChannelQRView.swift - Camera permission denied message */
-"chats.scanQR.permissionDenied.message" = "Ative o acesso à câmara em Definições para digitalizar códigos QR.";
+"chats.scanQR.permissionDenied.message" = "Ative o acesso à câmara em Definições para ler códigos QR.";
 
 /* Location: ScanChannelQRView.swift - Button to open settings */
 "chats.scanQR.openSettings" = "Abrir Definições";
@@ -607,7 +607,7 @@
 "chats.message.translatedAccessibility" = "Traduzido: %@";
 
 /* Location: UnifiedMessageBubble.swift - Context menu action to view repeat details */
-"chats.message.action.repeatDetails" = "Detalhes da repetição";
+"chats.message.action.repeatDetails" = "Detalhes da retransmissão";
 
 /* Location: UnifiedMessageBubble.swift - Context menu action to send again */
 "chats.message.action.sendAgain" = "Enviar novamente";
@@ -616,10 +616,10 @@
 "chats.message.info.heardRepeats" = "Receção: %d %@";
 
 /* Location: UnifiedMessageBubble.swift - Singular form of repeat */
-"chats.message.repeat.singular" = "repetição";
+"chats.message.repeat.singular" = "retransmissão";
 
 /* Location: UnifiedMessageBubble.swift - Plural form of repeats */
-"chats.message.repeat.plural" = "repetições";
+"chats.message.repeat.plural" = "retransmissões";
 
 /* Location: UnifiedMessageBubble.swift - Context menu text showing sent time - %@ is formatted date */
 "chats.message.info.sent" = "Enviado: %@";
@@ -628,13 +628,13 @@
 "chats.message.info.roundTrip" = "Ida e volta: %dms";
 
 /* Location: UnifiedMessageBubble.swift - Context menu action to view path */
-"chats.message.action.viewPath" = "Ver caminho";
+"chats.message.action.viewPath" = "Ver rota";
 
 /* Location: UnifiedMessageBubble.swift - Context menu text showing hop count - %@ is count or "Direct" */
 "chats.message.info.hops" = "Saltos: %@";
 
 /* Location: ActionsDetailsSection.swift - Info row showing the path hash size in bytes - %d is 1, 2, or 3 */
-"chats.message.info.pathHash" = "Hash do caminho: %d byte";
+"chats.message.info.pathHash" = "Hash da rota: %d byte";
 
 /* Location: UnifiedMessageBubble.swift - Indicator that timestamp was adjusted */
 "chats.message.info.adjusted" = "(ajustado)";
@@ -675,7 +675,7 @@
 "chats.message.action.blockSender" = "Bloquear remetente";
 
 /* Location: MessageActionsSheet.swift - Purpose: Action to start a DM with the channel sender */
-"chats.message.action.sendDM" = "Enviar DM";
+"chats.message.action.sendDM" = "Enviar mensagem direta";
 
 /* Location: UnifiedMessageBubble.swift - VoiceOver action to retry a failed send */
 "chats.message.action.retry" = "Tentar novamente";
@@ -753,12 +753,12 @@
 /* Location: UnifiedMessageBubble.swift - Path footer for direct messages (no hops) */
 "chats.message.path.direct" = "Direto";
 /* Routing strategy where the radio rebroadcasts the message to every neighbor (no specific path). UI displays this as a label in the per-message details sheet. Prefer a localized term over the English loanword if one exists in your locale's networking terminology. */
-"chats.message.path.flood" = "Flood";
+"chats.message.path.flood" = "Difusão";
 
 /* Location: UnifiedMessageBubble.swift - Fallback path showing hop count - %d is number */
 /* Location: MessagePathFormatter.swift - Fallback when path nodes unavailable */
 /* Location: UnifiedMessageBubble.swift - Accessibility label for routing path - %@ is the path */
-"chats.message.path.accessibilityLabel" = "Caminho de encaminhamento: %@";
+"chats.message.path.accessibilityLabel" = "Rota de encaminhamento: %@";
 
 /* Location: UnifiedMessageBubble.swift - Accessibility label for hop count display - %d is count */
 "chats.message.hopCount.accessibilityLabel" = "Número de saltos: %d";
@@ -773,13 +773,13 @@
 "chats.message.region.ambiguous.possibleMatch" = "Várias regiões correspondentes";
 
 /* Location: FallbackMatchIndicatorView.swift - Accessibility hint for region multi-match */
-"chats.message.region.ambiguous.possibleMatchHint" = "Mais de uma região da lista corresponde ao código de transporte deste pacote. A aplicação não consegue identificar qual foi usada.";
+"chats.message.region.ambiguous.possibleMatchHint" = "Mais do que uma região da lista corresponde ao código de transporte deste pacote. A app não consegue identificar qual foi usada.";
 
 /* Location: FallbackMatchIndicatorView.swift - Popover title for region multi-match */
 "chats.message.region.ambiguous.popoverTitle" = "Várias regiões correspondentes";
 
 /* Location: FallbackMatchIndicatorView.swift - Popover body; %@ is newline-prefixed list of candidate names */
-"chats.message.region.ambiguous.popoverBody" = "Mais de uma região da lista corresponde ao código de transporte deste pacote. A aplicação não consegue identificar qual foi usada.%@";
+"chats.message.region.ambiguous.popoverBody" = "Mais do que uma região da lista corresponde ao código de transporte deste pacote. A app não consegue identificar qual foi usada.%@";
 
 /* Location: BubbleFooterRow.swift - Accessibility label for the raw send time footer - %@ is the time */
 "chats.message.sendTime.accessibilityLabel" = "Hora de envio: %@";
@@ -862,7 +862,7 @@
 "chats.share.contact" = "Partilhar contacto";
 
 /* Location: ChatShareMenu.swift - Share menu action to share the user's own node info */
-"chats.share.myInfo" = "Partilhar as minhas informações";
+"chats.share.myInfo" = "Partilhar os meus dados";
 
 // MARK: - Contact Picker
 
@@ -878,26 +878,26 @@
 // MARK: - Message Path Sheet
 
 /* Location: MessagePathSheet.swift - Empty state title */
-"chats.path.unavailable.title" = "Caminho indisponível";
+"chats.path.unavailable.title" = "Rota indisponível";
 
 /* Location: MessagePathSheet.swift - Empty state description */
-"chats.path.unavailable.description" = "Os dados do caminho não estão disponíveis para esta mensagem";
+"chats.path.unavailable.description" = "Os dados da rota não estão disponíveis para esta mensagem";
 
 /* Location: MessagePathSheet.swift - Button to copy path */
-"chats.path.copyButton" = "Copiar caminho";
+"chats.path.copyButton" = "Copiar rota";
 
 /* Location: MessagePathSheet.swift - Accessibility label for copy button */
-"chats.path.copyAccessibility" = "Copiar caminho para a área de transferência";
+"chats.path.copyAccessibility" = "Copiar rota para a área de transferência";
 
 /* Location: MessagePathSheet.swift - Accessibility hint for copy button */
-"chats.path.copyHint" = "Copia os IDs dos nodos como valores hexadecimais";
+"chats.path.copyHint" = "Copia os IDs dos nós como valores hexadecimais";
 
 /* Location: MessagePathSheet.swift - Section header for path */
 /* Location: MessagePathMapView.swift - Path map button and sheet navigation title */
-"chats.path.map" = "Mapa do caminho";
+"chats.path.map" = "Mapa da rota";
 
 /* Location: MessagePathMapView.swift - Center on path map control accessibility label */
-"chats.path.centerOnPath" = "Centrar no caminho";
+"chats.path.centerOnPath" = "Centrar na rota";
 
 // MARK: - Path Hop Row View
 
@@ -911,7 +911,7 @@
 "chats.path.hop.possibleMatchTitle" = "Possível correspondência";
 
 /* Location: FallbackMatchIndicatorView.swift - Explanation of what a possible match means */
-"chats.path.hop.possibleMatchExplanation" = "Vários nodos partilham este prefixo. O nome apresentado pode não estar correto.";
+"chats.path.hop.possibleMatchExplanation" = "Vários nós partilham este prefixo. O nome apresentado pode não estar correto.";
 
 /* Location: PathHopRowView.swift - Label for sender (first hop) */
 "chats.path.hop.sender" = "Remetente";
@@ -920,13 +920,13 @@
 "chats.path.hop.number" = "Salto %d";
 
 /* Location: PathHopRowView.swift - Accessibility value format for last hop - %@ is quality, %@ is SNR */
-"chats.path.hop.signalQuality" = "Qualidade do sinal: %@, SNR %@ dB";
+"chats.path.hop.signalQuality" = "Sinal: %@, SNR %@ dB";
 
 /* Location: PathHopRowView.swift - Accessibility value format for non-last hops - %@ is hex ID */
-"chats.path.hop.nodeId" = "ID do nodo: %@";
+"chats.path.hop.nodeId" = "ID do nó: %@";
 
 /* Location: PathHopRowView.swift - Unknown signal quality */
-"chats.path.hop.signalUnknown" = "Desconhecida";
+"chats.path.hop.signalUnknown" = "Desconhecido";
 
 /* Location: PathHopRowView.swift - Label for receiver (your device) */
 "chats.path.receiver.label" = "Destinatário";
@@ -937,16 +937,16 @@
 // MARK: - Repeat Details Sheet
 
 /* Location: RepeatDetailsSheet.swift - Empty state title */
-"chats.repeats.emptyState.title" = "Ainda sem repetições";
+"chats.repeats.emptyState.title" = "Ainda sem retransmissões";
 
 /* Location: RepeatDetailsSheet.swift - Empty state description */
-"chats.repeats.emptyState.description" = "As repetições aparecem aqui à medida que a mensagem se propaga pela mesh";
+"chats.repeats.emptyState.description" = "As retransmissões aparecem aqui à medida que a mensagem se propaga pela mesh";
 
 /* Location: RepeatDetailsSheet.swift - Navigation title */
 // MARK: - Repeat Row View
 
 /* Location: RepeatRowView.swift - Accessibility label format - %@ is repeater name */
-"chats.repeats.row.accessibility" = "Repetição de %@";
+"chats.repeats.row.accessibility" = "Retransmissão de %@";
 
 /* Location: RepeatRowView.swift - Accessibility value format - %@ is quality, %@ is SNR, %@ is RSSI */
 "chats.repeats.row.accessibilityValue" = "Sinal %@, SNR %@, RSSI %@";
@@ -1026,7 +1026,7 @@
 "chats.common.cancel" = "Cancelar";
 
 /* Location: Various - Done button (use L10n.Localizable.Common.done) */
-"chats.common.done" = "OK";
+"chats.common.done" = "Concluído";
 
 // MARK: - Reaction Details Sheet
 
@@ -1085,7 +1085,7 @@
 "chats.tip.deviceMenu.title" = "Menu do dispositivo";
 
 /* Location: DeviceMenuTip.swift - Purpose: Tip message explaining device menu features */
-"chats.tip.deviceMenu.message" = "Faça a gestão da ligação, envie Adverts e consulte a bateria. O rádio permanece ligado mesmo depois de sair da aplicação à força. Toque em Desligar para interromper a ligação.";
+"chats.tip.deviceMenu.message" = "Faça a gestão da ligação, envie Adverts e consulte a bateria. O rádio permanece ligado mesmo depois de forçar o encerramento da app. Toque em Desligar para interromper a ligação.";
 
 // MARK: - Block Sender Sheet
 
@@ -1093,7 +1093,7 @@
 "chats.blockSender.title" = "Bloquear \"%@\"";
 
 /* Location: BlockSenderSheet.swift - Purpose: Explanation of name-based blocking limitation */
-"chats.blockSender.limitation" = "As mensagens de canal não incluem a identidade do remetente. Este bloqueio corresponde apenas pelo nome — o remetente pode alterar o nome para o contornar.";
+"chats.blockSender.limitation" = "As mensagens de canal não incluem a identidade do remetente. Este bloqueio baseia-se apenas no nome, que o remetente pode alterar para o contornar.";
 
 /* Location: BlockSenderSheet.swift - Purpose: Section header when matching contacts found */
 "chats.blockSender.matchingContacts" = "Os contactos seguintes partilham este nome. Selecione os que também devem ser bloqueados:";
@@ -1118,10 +1118,10 @@
 // MARK: - Send DM Sheet
 
 /* Location: SendDMSheet.swift - Purpose: Sheet title with sender name */
-"chats.sendDM.title" = "Enviar DM a \"%@\"";
+"chats.sendDM.title" = "Enviar mensagem direta a \"%@\"";
 
 /* Location: SendDMSheet.swift - Purpose: Name-based matching limitation warning */
-"chats.sendDM.limitation" = "As mensagens de canal não incluem a identidade do remetente. Esta correspondência é apenas pelo nome — o contacto pode ser outra pessoa com o mesmo nome.";
+"chats.sendDM.limitation" = "As mensagens de canal não incluem a identidade do remetente. O contacto é identificado apenas pelo nome, por isso pode ser outra pessoa com o mesmo nome.";
 
 /* Location: SendDMSheet.swift - Purpose: Section header listing matching contacts */
 "chats.sendDM.matchingContacts" = "Selecione um contacto para enviar mensagem:";
@@ -1146,7 +1146,7 @@
 "chats.channelInfo.region" = "Região";
 
 /* Location: ChannelInfoSheet.swift - Purpose: Region value when no scope set */
-"chats.channelInfo.region.allRegions" = "Sem âmbito";
+"chats.channelInfo.region.allRegions" = "Sem scope";
 
 /* Location: ChannelInfoSheet.swift - Purpose: Picker row and summary when channel inherits the device default flood scope */
 "chats.channelInfo.region.useDefaultFormat" = "%@ (predefinição)";
@@ -1188,7 +1188,7 @@
 "chats.channelInfo.region.errLoadingRepeaters" = "Não foi possível carregar os repetidores próximos";
 
 /* Location: ChannelInfoSheet.swift - Purpose: Some queries failed because radio contact list is full */
-"chats.channelInfo.region.errRadioContactsFull" = "A lista de contactos do rádio está cheia — alguns repetidores não puderam ser consultados";
+"chats.channelInfo.region.errRadioContactsFull" = "A lista de contactos do rádio está cheia. Não foi possível obter dados de alguns repetidores";
 
 /* Location: RegionDiscoveryResultsView.swift - Purpose: Add selected regions button */
 "chats.channelInfo.region.addSelected" = "Adicionar";
@@ -1231,10 +1231,10 @@
 "chats.mention.picker.notSavedSubtitle" = "@%@ não corresponde a nenhum contacto neste rádio.";
 
 /* Location: ChatConversationView.swift - Mention picker title when the tapped name is the user's own node */
-"chats.mention.picker.selfTitle" = "É o nodo local";
+"chats.mention.picker.selfTitle" = "É o seu nó";
 
 /* Location: ChatConversationView.swift - Mention picker description when the tapped name is the user's own node */
-"chats.mention.picker.selfSubtitle" = "@%@ é o nome deste nodo.";
+"chats.mention.picker.selfSubtitle" = "@%@ é o nome deste nó.";
 
 /* Location: ChatConversationView.swift - Mention picker section header above the list of matching contacts */
 "chats.mention.picker.matchingContacts" = "Contactos correspondentes";
@@ -1245,7 +1245,7 @@
 "chats.message.sender.unverifiedNickname" = "Nome não verificado";
 
 /* Location: UnifiedMessageBubble.swift - Explanation of why the sender name is unverified */
-"chats.message.sender.unverifiedNicknameExplanation" = "Os remetentes de mensagens de canal não podem ser verificados. Pode ser outra pessoa.";
+"chats.message.sender.unverifiedNicknameExplanation" = "Os remetentes das mensagens do canal não podem ser verificados. Pode tratar-se de outra pessoa.";
 
 /* Location: UnifiedMessageBubble.swift - Accessibility label for unverified nickname indicator */
 "chats.message.sender.unverifiedNicknameAccessibilityLabel" = "Correspondência de nome não verificado";

--- a/MC1/Resources/Localization/pt.lproj/Contacts.strings
+++ b/MC1/Resources/Localization/pt.lproj/Contacts.strings
@@ -18,7 +18,7 @@
 "contacts.common.save" = "Guardar";
 
 /* Location: Multiple files - Purpose: Generic Done button */
-"contacts.common.done" = "OK";
+"contacts.common.done" = "Concluído";
 
 /* Location: Multiple files - Purpose: Generic Delete button */
 "contacts.common.delete" = "Eliminar";
@@ -53,7 +53,7 @@
 // MARK: - Route Types
 
 /* Location: ContactDetailView.swift, ContactRowView.swift - Purpose: Flood routing label */
-"contacts.route.flood" = "Flood";
+"contacts.route.flood" = "Difusão";
 
 /* Location: ContactDetailView.swift, ContactRowView.swift - Purpose: Direct routing label */
 "contacts.route.direct" = "Direto";
@@ -76,12 +76,12 @@
 "contacts.segment.rooms" = "Salas";
 
 /* Location: NodeSegmentPicker.swift - Purpose: VoiceOver label for the Nodes tab segment filter picker (iOS 18 fallback) */
-"contacts.segment.pickerLabel" = "Filtrar nodos";
+"contacts.segment.pickerLabel" = "Filtrar nós";
 
 // MARK: - Sort Order
 
 /* Location: ContactsViewModel.swift - Purpose: Last heard sort option */
-"contacts.sort.lastHeard" = "Última receção";
+"contacts.sort.lastHeard" = "Última alteração";
 
 /* Location: ContactsViewModel.swift - Purpose: Name sort option */
 "contacts.sort.name" = "Nome";
@@ -95,13 +95,13 @@
 // MARK: - Contacts List
 
 /* Location: ContactsListView.swift - Purpose: Navigation title */
-"contacts.list.title" = "Nodos";
+"contacts.list.title" = "Nós";
 
 /* Location: ContactsListView.swift - Purpose: Search prompt */
-"contacts.list.searchPrompt" = "Pesquisar nodos";
+"contacts.list.searchPrompt" = "Pesquisar nós";
 
 /* Location: ContactsListView.swift - Purpose: Search prompt with count */
-"contacts.list.searchPromptWithCount" = "Pesquisar nodos (%d)";
+"contacts.list.searchPromptWithCount" = "Pesquisar nós (%d)";
 
 /* Location: ContactsListView.swift - Purpose: Sort menu label */
 "contacts.list.sort" = "Ordenar";
@@ -122,10 +122,10 @@
 "contacts.list.discover" = "Descobrir";
 
 /* Location: ContactsListView.swift - Purpose: Menu item to sync nodes */
-"contacts.list.syncNodes" = "Sincronizar nodos";
+"contacts.list.syncNodes" = "Sincronizar nós";
 
 /* Location: ContactsListView.swift - Purpose: Empty state for split view */
-"contacts.list.selectNode" = "Selecione um nodo";
+"contacts.list.selectNode" = "Selecione um nó";
 
 /* Location: ContactsListView.swift - Purpose: Refresh alert title */
 "contacts.list.cannotRefresh" = "Não é possível atualizar";
@@ -151,7 +151,7 @@
 "contacts.list.empty.favorites.title" = "Ainda não há favoritos";
 
 /* Location: ContactsListView.swift - Purpose: No favorites empty description */
-"contacts.list.empty.favorites.description" = "Toque e mantenha premido qualquer nodo para o adicionar aos favoritos.";
+"contacts.list.empty.favorites.description" = "Mantenha premido qualquer nó para o adicionar aos favoritos.";
 
 /* Location: ContactsListView.swift - Purpose: No contacts empty title */
 "contacts.list.empty.contacts.title" = "Nenhum contacto";
@@ -175,7 +175,7 @@
 "contacts.list.empty.search.title" = "Nenhum resultado";
 
 /* Location: ContactsListView.swift - Purpose: No search results description */
-"contacts.list.empty.search.description" = "Nenhum nodo corresponde a '%@'";
+"contacts.list.empty.search.description" = "Nenhum nó corresponde a '%@'";
 
 // MARK: - Contacts List Row
 
@@ -244,7 +244,7 @@
 "contacts.detail.shareViaAdvert" = "Partilhar contacto via Advert";
 
 /* Location: ContactDetailView.swift - Purpose: Share contact error when advert is missing or stale */
-"contacts.detail.shareContactUnavailable" = "Não foi possível partilhar o nodo. O Advert do nodo pode estar em falta ou ser demasiado antigo.";
+"contacts.detail.shareContactUnavailable" = "Não foi possível partilhar o nó. O Advert do nó pode estar em falta ou ser demasiado antigo.";
 
 /* Location: ContactDetailView.swift - Purpose: Generalized ping button for non-repeater nodes */
 "contacts.detail.ping" = "Ping zero-hop";
@@ -343,7 +343,7 @@
 // MARK: - Contact Detail Network Path Section
 
 /* Location: ContactDetailView.swift - Purpose: Outbound path section header */
-"contacts.detail.outboundPath" = "Caminho de saída";
+"contacts.detail.outboundPath" = "Rota de saída";
 
 /* Location: ContactDetailView.swift - Purpose: Route label */
 "contacts.detail.route" = "Rota";
@@ -355,28 +355,28 @@
 "contacts.detail.hopsAway" = "Distância em saltos";
 
 /* Location: ContactDetailView.swift - Purpose: Path discovery in progress */
-"contacts.detail.discoveringPath" = "A descobrir o caminho...";
+"contacts.detail.discoveringPath" = "A descobrir a rota...";
 
 /* Location: ContactDetailView.swift - Purpose: Discovery countdown */
 "contacts.detail.secondsRemaining" = "Até %d segundos restantes";
 
 /* Location: ContactDetailView.swift - Purpose: Discover path button */
-"contacts.detail.discoverPath" = "Descobrir caminho";
+"contacts.detail.discoverPath" = "Descobrir rota";
 
 /* Location: ContactDetailView.swift - Purpose: Edit path button */
-"contacts.detail.editPath" = "Editar caminho";
+"contacts.detail.editPath" = "Editar rota";
 
 /* Location: ContactDetailView.swift - Purpose: Reset path button */
-"contacts.detail.resetPath" = "Repor caminho";
+"contacts.detail.resetPath" = "Repor rota";
 
 /* Location: ContactDetailView.swift - Purpose: Footer for flood routing */
-"contacts.detail.floodFooter" = "As mensagens são enviadas a todos os nodos. Use Descobrir caminho para encontrar uma rota ideal.";
+"contacts.detail.floodFooter" = "As mensagens são enviadas a todos os nós. Use Descobrir rota para encontrar a melhor.";
 
 /* Location: ContactDetailView.swift - Purpose: Footer for path routing */
-"contacts.detail.pathFooter" = "As mensagens seguem o caminho mostrado. Repor o caminho para usar o encaminhamento Flood.";
+"contacts.detail.pathFooter" = "As mensagens seguem a rota mostrada. Reponha-a para voltar à difusão.";
 
 /* Location: ContactDetailView.swift - Purpose: Accessibility label for flood route */
-"contacts.detail.routeFlood" = "Rota: Flood";
+"contacts.detail.routeFlood" = "Rota: Difusão";
 
 /* Location: ContactDetailView.swift - Purpose: Accessibility label for direct route */
 "contacts.detail.routeDirect" = "Rota: Direto";
@@ -387,7 +387,7 @@
 // MARK: - Contact Detail Technical Section
 
 /* Location: ContactDetailView.swift - Purpose: Technical section header */
-"contacts.detail.technical" = "Técnico";
+"contacts.detail.technical" = "Detalhes técnicos";
 
 /* Location: ContactDetailView.swift - Purpose: Public key label */
 "contacts.detail.publicKey" = "Chave pública";
@@ -398,7 +398,7 @@
 // MARK: - Contact Detail Danger Section
 
 /* Location: ContactDetailView.swift - Purpose: Danger zone section header */
-"contacts.detail.dangerZone" = "Zona de perigo";
+"contacts.detail.dangerZone" = "Zona perigosa";
 
 /* Location: ContactDetailView.swift - Purpose: Clear messages button */
 "contacts.detail.clearMessages" = "Limpar mensagens";
@@ -421,25 +421,25 @@
 "contacts.detail.alert.block.title" = "Bloquear contacto";
 
 /* Location: ContactDetailView.swift - Purpose: Block contact alert message */
-"contacts.detail.alert.block.message" = "Não serão recebidas mensagens de %@. As conversas desse contacto ficam ocultas na lista de Chats e as novas mensagens de canal são descartadas. Ao desbloquear, as novas mensagens passam a ser permitidas, mas as mensagens descartadas não podem ser recuperadas.";
+"contacts.detail.alert.block.message" = "Deixará de receber mensagens de %@. A conversa fica oculta na lista e as mensagens deste contacto nos canais são ignoradas. Se desbloquear, volta a receber mensagens, mas as que foram ignoradas não são recuperadas.";
 
 /* Location: ContactDetailView.swift - Purpose: Delete contact alert title */
 "contacts.detail.alert.delete.title" = "Eliminar %@";
 
 /* Location: ContactDetailView.swift - Purpose: Delete contact alert message */
-"contacts.detail.alert.delete.message" = "Isto irá remover %@ e eliminar todos os dados associados. Esta ação não pode ser anulada.";
+"contacts.detail.alert.delete.message" = "%@ e todos os dados associados são eliminados. Esta ação não pode ser anulada.";
 
 /* Location: ContactDetailView.swift - Purpose: Clear messages alert title */
 "contacts.detail.alert.clearMessages.title" = "Limpar mensagens?";
 
 /* Location: ContactDetailView.swift - Purpose: Clear messages alert message */
-"contacts.detail.alert.clearMessages.message" = "Todas as mensagens com %@ serão eliminadas de forma permanente.";
+"contacts.detail.alert.clearMessages.message" = "Todas as mensagens com %@ são eliminadas de forma permanente.";
 
 /* Location: ContactDetailView.swift - Purpose: Path error alert title */
-"contacts.detail.alert.pathError" = "Erro de caminho";
+"contacts.detail.alert.pathError" = "Erro de rota";
 
 /* Location: ContactDetailView.swift - Purpose: Path discovery alert title */
-"contacts.detail.alert.pathDiscovery" = "Descoberta de caminho";
+"contacts.detail.alert.pathDiscovery" = "Descoberta de rota";
 
 // MARK: - Blocked Contacts
 
@@ -459,13 +459,13 @@
 
 /* Location: AddContactSheet.swift - Purpose: Navigation title */
 "contacts.add.title" = "Adicionar contacto";
-"contacts.add.nodeTitle" = "Adicionar nodo";
+"contacts.add.nodeTitle" = "Adicionar nó";
 
 /* Location: AddContactSheet.swift - Purpose: Add button */
 "contacts.add.add" = "Adicionar";
 
 /* Location: AddContactSheet.swift - Purpose: Scan QR button label */
-"contacts.add.scanQR" = "Digitalizar código QR";
+"contacts.add.scanQR" = "Ler código QR";
 
 /* Location: AddContactSheet.swift - Purpose: Type section header */
 "contacts.add.type" = "Tipo";
@@ -501,10 +501,10 @@
 "contacts.add.error.invalidSize" = "A chave pública tem de ter %d bytes (%d caracteres hexadecimais)";
 
 /* Location: AddContactSheet.swift, DiscoveryView.swift - Purpose: Node list full error with max count */
-"contacts.add.error.nodeListFull" = "A lista de nodos está cheia (máximo de %d nodos)";
+"contacts.add.error.nodeListFull" = "A lista de nós está cheia (máximo de %d nós)";
 
 /* Location: AddContactSheet.swift, DiscoveryView.swift - Purpose: Node list full error without max count */
-"contacts.add.error.nodeListFullSimple" = "A lista de nodos está cheia";
+"contacts.add.error.nodeListFullSimple" = "A lista de nós está cheia";
 
 /* Location: AddContactSheet.swift - Purpose: Paste URL button label */
 "contacts.add.pasteURL" = "Colar URL do contacto";
@@ -541,13 +541,13 @@
 // MARK: - Scan Contact QR
 
 /* Location: ScanContactQRView.swift - Purpose: Navigation title */
-"contacts.scan.title" = "Digitalizar código QR";
+"contacts.scan.title" = "Ler código QR";
 
 /* Location: ScanContactQRView.swift - Purpose: Scanner not available title */
 "contacts.scan.unavailable.title" = "Scanner indisponível";
 
 /* Location: ScanContactQRView.swift - Purpose: Scanner not available description */
-"contacts.scan.unavailable.description" = "A digitalização de códigos QR não é suportada neste dispositivo";
+"contacts.scan.unavailable.description" = "A leitura de códigos QR não é suportada neste dispositivo";
 
 /* Location: ScanContactQRView.swift - Purpose: Importing progress */
 "contacts.scan.importing" = "A importar o contacto...";
@@ -559,7 +559,7 @@
 "contacts.scan.permission.title" = "É necessário o acesso à câmara";
 
 /* Location: ScanContactQRView.swift - Purpose: Camera permission description */
-"contacts.scan.permission.description" = "Ative o acesso à câmara em Definições para digitalizar códigos QR.";
+"contacts.scan.permission.description" = "Ative o acesso à câmara em Definições para ler códigos QR.";
 
 /* Location: ScanContactQRView.swift - Purpose: Invalid QR format error */
 "contacts.scan.error.invalidFormat" = "Formato de código QR inválido";
@@ -575,10 +575,10 @@
 "contacts.discovery.title" = "Descobrir";
 
 /* Location: DiscoveryView.swift - Purpose: Empty state title */
-"contacts.discovery.empty.title" = "Nenhum nodo descoberto";
+"contacts.discovery.empty.title" = "Nenhum nó descoberto";
 
 /* Location: DiscoveryView.swift - Purpose: Empty state description */
-"contacts.discovery.empty.description" = "Os nodos aparecem aqui à medida que os respetivos Adverts são descobertos.";
+"contacts.discovery.empty.description" = "Os nós aparecem aqui à medida que os respetivos Adverts são descobertos.";
 
 /* Location: DiscoveryView.swift - Purpose: Add button */
 "contacts.discovery.add" = "Adicionar";
@@ -603,7 +603,7 @@
 "contacts.discovery.segment.rooms" = "Salas";
 
 /* Location: DiscoverSegmentPicker.swift - Purpose: VoiceOver label for the Discovery segment filter picker (iOS 18 fallback) */
-"contacts.discovery.segment.pickerLabel" = "Filtrar nodos descobertos";
+"contacts.discovery.segment.pickerLabel" = "Filtrar nós descobertos";
 
 /* Location: DiscoveryView.swift - Purpose: Search prompt */
 "contacts.discovery.searchPrompt" = "Pesquisar descobertos";
@@ -615,10 +615,10 @@
 "contacts.discovery.clear" = "Limpar tudo";
 
 /* Location: DiscoveryView.swift - Purpose: Clear confirmation title */
-"contacts.discovery.clear.title" = "Limpar todos os nodos descobertos?";
+"contacts.discovery.clear.title" = "Limpar todos os nós descobertos?";
 
 /* Location: DiscoveryView.swift - Purpose: Clear confirmation message */
-"contacts.discovery.clear.message" = "Os nodos descobertos serão removidos desta lista, mas podem ser descobertos novamente na rede mesh.";
+"contacts.discovery.clear.message" = "Os nós descobertos serão removidos desta lista, mas podem ser descobertos novamente na rede mesh.";
 
 /* Location: DiscoveryView.swift - Purpose: Clear confirmation button */
 "contacts.discovery.clear.confirm" = "Limpar";
@@ -630,10 +630,10 @@
 "contacts.discovery.sortMenu" = "Opções de ordenação";
 
 /* Location: DiscoveryView.swift - Purpose: Sort menu accessibility hint */
-"contacts.discovery.sortMenuHint" = "Escolha como ordenar os nodos descobertos";
+"contacts.discovery.sortMenuHint" = "Escolha como ordenar os nós descobertos";
 
 /* Location: DiscoveryView.swift - Purpose: VoiceOver announcement after clearing */
-"contacts.discovery.clearedAllNodes" = "Todos os nodos descobertos foram limpos";
+"contacts.discovery.clearedAllNodes" = "Todos os nós descobertos foram limpos";
 
 /* Location: DiscoveryView.swift - Purpose: Swipe action to remove discovered node */
 "contacts.discovery.remove" = "Remover";
@@ -642,18 +642,18 @@
 "contacts.discovery.empty.search.title" = "Nenhum resultado";
 
 /* Location: DiscoveryView.swift - Purpose: Search empty state description */
-"contacts.discovery.empty.search.description" = "Nenhum nodo descoberto corresponde a '%@'";
+"contacts.discovery.empty.search.description" = "Nenhum nó descoberto corresponde a '%@'";
 
 // MARK: - Path Editing Sheet
 
 /* Location: PathEditingSheet.swift - Purpose: Navigation title */
-"contacts.pathEdit.title" = "Editar caminho";
+"contacts.pathEdit.title" = "Editar rota";
 
 /* Location: PathEditingSheet.swift - Purpose: Description with contact name */
 "contacts.pathEdit.description" = "Personalize a rota que as mensagens seguem para chegar a %@.";
 
 /* Location: PathEditingSheet.swift - Purpose: Current path section header */
-"contacts.pathEdit.currentPath" = "Caminho atual";
+"contacts.pathEdit.currentPath" = "Rota atual";
 
 /* Location: AddHopPickerView.swift - Purpose: No repeaters empty title */
 "contacts.pathEdit.noRepeaters.title" = "Nenhum repetidor disponível";
@@ -671,7 +671,7 @@
 "contacts.pathEdit.noRecent.title" = "Nenhum repetidor recente";
 
 /* Location: AddHopPickerView.swift - Purpose: No recent repeaters empty description */
-"contacts.pathEdit.noRecent.description" = "Os repetidores adicionados a um caminho aparecem aqui.";
+"contacts.pathEdit.noRecent.description" = "Os repetidores adicionados a uma rota aparecem aqui.";
 
 /* Location: PathEditingSheet.swift - Purpose: Hop accessibility with name */
 "contacts.pathEdit.hopWithName" = "Salto %d de %d: %@";
@@ -686,13 +686,13 @@
 "contacts.pathEdit.paste" = "Colar da área de transferência";
 
 /* Location: PathEditingSheet.swift - Purpose: Use-direct-routing empty-state button */
-"contacts.pathEdit.useDirectRouting" = "Usar encaminhamento direto";
+"contacts.pathEdit.useDirectRouting" = "Usar rota direta";
 
 /* Location: PathEditingSheet.swift - Purpose: Use-flood-routing empty-state button */
-"contacts.pathEdit.useFloodRouting" = "Usar encaminhamento Flood";
+"contacts.pathEdit.useFloodRouting" = "Usar difusão";
 
 /* Location: PathEditingSheet.swift - Purpose: Direct-routing confirmation alert title */
-"contacts.pathEdit.directRouting.confirm.title" = "Guardar como encaminhamento direto?";
+"contacts.pathEdit.directRouting.confirm.title" = "Guardar como rota direta?";
 
 /* Location: PathEditingSheet.swift - Purpose: Direct-routing confirmation alert message, %@ is contact name */
 "contacts.pathEdit.directRouting.confirm.message" = "As mensagens para %@ serão enviadas diretamente, sem passar por nenhum repetidor. Use apenas se %@ for um vizinho direto (0-hop).";
@@ -701,13 +701,13 @@
 "contacts.pathEdit.directRouting.confirm.confirm" = "Guardar como direto";
 
 /* Location: PathEditingSheet.swift - Purpose: Flood-routing confirmation alert title */
-"contacts.pathEdit.floodRouting.confirm.title" = "Usar encaminhamento Flood?";
+"contacts.pathEdit.floodRouting.confirm.title" = "Usar rota por difusão?";
 
 /* Location: PathEditingSheet.swift - Purpose: Flood-routing confirmation alert message, %@ is contact name */
-"contacts.pathEdit.floodRouting.confirm.message" = "As mensagens para %@ serão enviadas a todos os nodos próximos até ser encontrado um caminho. Use quando não for conhecida nenhuma rota de repetidor.";
+"contacts.pathEdit.floodRouting.confirm.message" = "As mensagens para %@ serão enviadas a todos os nós próximos até ser encontrada uma rota. Use quando não for conhecida nenhuma rota de repetidor.";
 
 /* Location: PathEditingSheet.swift - Purpose: Flood-routing confirmation confirm label */
-"contacts.pathEdit.floodRouting.confirm.confirm" = "Usar encaminhamento Flood";
+"contacts.pathEdit.floodRouting.confirm.confirm" = "Usar rota por difusão";
 
 /* Location: AddHopPickerView.swift - Purpose: Position banner when appending, %d is target hop number */
 "contacts.pathEdit.positionAppend" = "A adicionar como salto %d";
@@ -722,7 +722,7 @@
 "contacts.pathEdit.empty.title" = "Ainda não há saltos";
 
 /* Location: PathEditingSheet.swift - Purpose: Empty-state description, %@ is contact name */
-"contacts.pathEdit.empty.description" = "Adicione repetidores para controlar como as mensagens chegam a %@ ou use o encaminhamento Flood se o caminho não for conhecido.";
+"contacts.pathEdit.empty.description" = "Adicione repetidores para controlar como as mensagens chegam a %@, ou use a difusão se a rota não for conhecida.";
 
 /* Location: AddHopSegmentPicker.swift - Purpose: All filter */
 "contacts.pathEdit.filter.all" = "Todos";
@@ -758,7 +758,7 @@
 "contacts.pathEdit.search.noMatches.descriptionWithRoomsHint" = "Tente um nome ou um prefixo hexadecimal como 'a3'. As salas só aparecem no filtro Todos.";
 
 /* Location: AddHopPickerView.swift - Purpose: Picker row accessibility label, %1$@ is name, %2$d is target hop number */
-"contacts.pathEdit.addToPathAsHop" = "Adicionar %1$@ ao caminho como salto %2$d";
+"contacts.pathEdit.addToPathAsHop" = "Adicionar %1$@ à rota como salto %2$d";
 
 /* Location: PathEditingSheet.swift - Purpose: VoiceOver hint for a hop row describing swipe + drag actions */
 "contacts.pathEdit.hopHint" = "Deslize para eliminar. Arraste para reordenar.";
@@ -770,13 +770,13 @@
 "contacts.pathEdit.maxHops.reached" = "Máximo de saltos atingido";
 
 /* Location: AddHopPickerView.swift - Purpose: Max-hops reached description, %d is the cap */
-"contacts.pathEdit.maxHops.description" = "Este caminho atingiu o máximo de %d saltos no modo de hash atual. Remova um salto para adicionar outro.";
+"contacts.pathEdit.maxHops.description" = "Esta rota atingiu o máximo de %d saltos no modo de hash atual. Remova um salto para adicionar outro.";
 
 /* Location: PathEditingSheet.swift - Purpose: Add Hop CTA footer explaining the hop cap, %d is the cap */
 "contacts.pathEdit.maxHops.footer" = "Máximo de %d saltos atingido. Remova um salto para adicionar outro.";
 
 /* Location: AddHopPickerView.swift - Purpose: Bulk-add action button, %@ is the comma-joined codes */
-"contacts.pathEdit.bulkAdd.action" = "Adicionar nodos: %@";
+"contacts.pathEdit.bulkAdd.action" = "Adicionar nós: %@";
 
 /* Location: AddHopPickerView.swift - Purpose: Bulk-add row, code will be added, %@ is the code */
 "contacts.pathEdit.bulkAdd.willAdd" = "%@ será adicionado";
@@ -785,7 +785,7 @@
 "contacts.pathEdit.bulkAdd.pathFull" = "%@ excede o limite de saltos";
 
 /* Location: AddHopPickerView.swift - Purpose: Bulk-add action button when nothing is addable */
-"contacts.pathEdit.bulkAdd.empty" = "Não há nodos novos para adicionar";
+"contacts.pathEdit.bulkAdd.empty" = "Não há nós novos para adicionar";
 
 // MARK: - Path Discovery Results
 
@@ -799,7 +799,7 @@
 "contacts.pathDiscovery.hops.plural" = "%d saltos";
 
 /* Location: PathManagementViewModel.swift - Purpose: No response message */
-"contacts.pathDiscovery.noResponse" = "O nodo remoto não respondeu. Os nodos precisam de ter os pedidos de telemetria ativados para responder à descoberta de caminho.";
+"contacts.pathDiscovery.noResponse" = "O nó remoto não respondeu. Só é possível traçar a rota se o nó tiver os pedidos de telemetria ativados.";
 
 /* Location: PathManagementViewModel.swift - Purpose: Failed prefix */
 "contacts.pathDiscovery.failed" = "Falha: %@";
@@ -807,25 +807,25 @@
 // MARK: - Saved Paths Sheet
 
 /* Location: SavedPathsSheet.swift - Purpose: Navigation title */
-"contacts.savedPaths.title" = "Caminhos guardados";
+"contacts.savedPaths.title" = "Rotas guardadas";
 
 /* Location: SavedPathsSheet.swift - Purpose: Delete dialog title */
-"contacts.savedPaths.deleteTitle" = "Eliminar caminho";
+"contacts.savedPaths.deleteTitle" = "Eliminar rota";
 
 /* Location: SavedPathsSheet.swift - Purpose: Delete dialog message */
-"contacts.savedPaths.deleteMessage" = "Eliminar \"%@\"? Isto irá remover o caminho e todo o histórico de execuções.";
+"contacts.savedPaths.deleteMessage" = "Eliminar \"%@\"? Isto remove a rota e todo o histórico de execuções.";
 
 /* Location: SavedPathsSheet.swift - Purpose: Rename alert title */
-"contacts.savedPaths.renameTitle" = "Renomear caminho";
+"contacts.savedPaths.renameTitle" = "Renomear rota";
 
 /* Location: SavedPathsSheet.swift - Purpose: Rename context menu */
 "contacts.savedPaths.rename" = "Renomear";
 
 /* Location: SavedPathsSheet.swift - Purpose: Empty state title */
-"contacts.savedPaths.empty.title" = "Nenhum caminho guardado";
+"contacts.savedPaths.empty.title" = "Nenhuma rota guardada";
 
 /* Location: SavedPathsSheet.swift - Purpose: Empty state description */
-"contacts.savedPaths.empty.description" = "Guarde caminhos depois de executar traçados para os voltar a executar mais tarde.";
+"contacts.savedPaths.empty.description" = "Guarde as rotas depois de as traçar, para as voltar a executar mais tarde.";
 
 /* Location: SavedPathsSheet.swift - Purpose: Run count singular */
 "contacts.savedPaths.runs.singular" = "1 execução";
@@ -846,7 +846,7 @@
 "contacts.savedPaths.health.poor" = "fraco";
 
 /* Location: SavedPathsSheet.swift - Purpose: Health accessibility label */
-"contacts.savedPaths.healthLabel" = "Estado do caminho: %@, taxa de sucesso de %d%%";
+"contacts.savedPaths.healthLabel" = "Estado da rota: %@, taxa de sucesso de %d%%";
 
 /* Location: SavedPathsSheet.swift - Purpose: Response times accessibility */
 "contacts.savedPaths.responseTimes" = "Tempos de resposta: média de %dms, %@";
@@ -866,7 +866,7 @@
 // MARK: - Saved Path Detail
 
 /* Location: SavedPathDetailView.swift - Purpose: Path section header */
-"contacts.pathDetail.path" = "Caminho";
+"contacts.pathDetail.path" = "Rota";
 
 /* Location: SavedPathDetailView.swift - Purpose: Performance section header */
 "contacts.pathDetail.performance" = "Desempenho";
@@ -913,7 +913,7 @@
 // MARK: - Trace Path View
 
 /* Location: TracePathView.swift - Purpose: Navigation title */
-"contacts.trace.title" = "Traçar caminho";
+"contacts.trace.title" = "Traçar rota";
 
 /* Location: TracePathView.swift - Purpose: View mode picker label */
 "contacts.trace.viewMode" = "Modo de visualização";
@@ -928,45 +928,45 @@
 "contacts.trace.saved" = "Guardados";
 
 /* Location: TracePathView.swift - Purpose: Clear path dialog title */
-"contacts.trace.clearPath" = "Limpar caminho";
+"contacts.trace.clearPath" = "Limpar rota";
 
 /* Location: TracePathView.swift - Purpose: Clear path dialog message */
-"contacts.trace.clearPathMessage" = "Remover todos os repetidores do caminho?";
+"contacts.trace.clearPathMessage" = "Remover todos os repetidores da rota?";
 
 /* Location: TracePathView.swift - Purpose: Trace failed alert title */
-"contacts.trace.failed" = "Falha no traçado";
+"contacts.trace.failed" = "Falha ao traçar";
 
 /* Location: TracePathView.swift - Purpose: Jump button label */
 "contacts.trace.runBelow" = "Ir para Executar";
 
 /* Location: TracePathView.swift - Purpose: Jump button accessibility label */
-"contacts.trace.jumpLabel" = "Ir para o botão Executar traçado";
+"contacts.trace.jumpLabel" = "Ir para o botão Traçar rota";
 
 /* Location: TracePathView.swift - Purpose: Jump button accessibility hint */
-"contacts.trace.jumpHint" = "Toque duas vezes para ir até ao fim do caminho";
+"contacts.trace.jumpHint" = "Toque duas vezes para ir até ao fim da rota";
 
 // MARK: - Trace Path List View
 
 /* Location: TracePathListView.swift - Purpose: Empty path instruction */
-"contacts.trace.list.emptyPath" = "Adicione um salto para começar a montar o caminho.";
+"contacts.trace.list.emptyPath" = "Adicione um salto para começar a montar a rota.";
 
 /* Location: TracePathListView.swift - Purpose: Round trip path section header */
-"contacts.trace.list.roundTripPath" = "Caminho de ida e volta";
+"contacts.trace.list.roundTripPath" = "Rota de ida e volta";
 
 /* Location: TracePathListView.swift - Purpose: Auto return toggle label */
-"contacts.trace.list.autoReturn" = "Caminho de regresso automático";
+"contacts.trace.list.autoReturn" = "Rota de regresso automático";
 
 /* Location: TracePathListView.swift - Purpose: Auto return toggle description */
-"contacts.trace.list.autoReturnDescription" = "Espelhar o caminho de saída no regresso";
+"contacts.trace.list.autoReturnDescription" = "Espelhar a rota de saída no regresso";
 
 /* Location: TracePathListView.swift - Purpose: Batch trace toggle label */
-"contacts.trace.list.batchTrace" = "Traçado em lote";
+"contacts.trace.list.batchTrace" = "Traçar em lote";
 
 /* Location: TracePathListView.swift - Purpose: Batch trace toggle description */
-"contacts.trace.list.batchTraceDescription" = "Executar vários traçados e calcular a média dos resultados";
+"contacts.trace.list.batchTraceDescription" = "Traçar a rota várias vezes e calcular a média dos resultados";
 
 /* Location: TracePathListView.swift - Purpose: Traces count label */
-"contacts.trace.list.traces" = "Traçados:";
+"contacts.trace.list.traces" = "Tentativas:";
 
 /* Location: PathActionsSectionView.swift - Purpose: Trace hash size picker label */
 "contacts.trace.list.hashSize" = "Tamanho do hash";
@@ -981,37 +981,37 @@
 "contacts.trace.list.hashSizeFourBytes" = "4 bytes";
 
 /* Location: PathActionsSectionView.swift - Purpose: Caveat shown for multi-byte trace hash sizes */
-"contacts.trace.list.hashSizeFooter" = "Os repetidores com firmware anterior a 1.11.0 não reencaminham traçados com um tamanho de hash superior a 1 byte.";
+"contacts.trace.list.hashSizeFooter" = "Os repetidores com firmware anterior a 1.11.0 não reencaminham pedidos com um tamanho do hash da rota superior a 1 byte.";
 
 /* Location: TracePathListView.swift - Purpose: Copy path button */
-"contacts.trace.list.copyPath" = "Copiar caminho";
+"contacts.trace.list.copyPath" = "Copiar rota";
 
 /* Location: TracePathListView.swift - Purpose: Range warning footer */
 "contacts.trace.list.rangeWarning" = "É necessário estar ao alcance do último repetidor para receber uma resposta.";
 
 /* Location: TracePathListView.swift - Purpose: Running trace progress */
-"contacts.trace.list.runningTrace" = "A executar o traçado";
+"contacts.trace.list.runningTrace" = "A traçar a rota";
 
 /* Location: TracePathListView.swift - Purpose: Running trace with batch count */
-"contacts.trace.list.runningBatch" = "A executar o traçado %d de %d";
+"contacts.trace.list.runningBatch" = "A traçar %d de %d";
 
 /* Location: TracePathListView.swift - Purpose: Run trace button */
-"contacts.trace.list.runTrace" = "Executar traçado";
+"contacts.trace.list.runTrace" = "Traçar";
 
 /* Location: TracePathListView.swift - Purpose: Run trace accessibility label */
-"contacts.trace.list.runTraceLabel" = "Executar traçado";
+"contacts.trace.list.runTraceLabel" = "Traçar rota";
 
 /* Location: TracePathListView.swift - Purpose: Batch run accessibility hint */
-"contacts.trace.list.batchHint" = "Toque duas vezes para executar %d traçados";
+"contacts.trace.list.batchHint" = "Toque duas vezes para traçar %d vezes";
 
 /* Location: TracePathListView.swift - Purpose: Single run accessibility hint */
-"contacts.trace.list.singleHint" = "Toque duas vezes para traçar o caminho";
+"contacts.trace.list.singleHint" = "Toque duas vezes para traçar a rota";
 
 /* Location: TracePathListView.swift - Purpose: Running accessibility label */
-"contacts.trace.list.runningLabel" = "A executar o traçado, aguarde";
+"contacts.trace.list.runningLabel" = "A traçar a rota, aguarde";
 
 /* Location: TracePathListView.swift - Purpose: Running batch accessibility label */
-"contacts.trace.list.runningBatchLabel" = "A executar o traçado %d de %d";
+"contacts.trace.list.runningBatchLabel" = "A traçar %d de %d";
 
 /* Location: TracePathListView.swift - Purpose: Hop row accessibility label */
 "contacts.trace.list.hopLabel" = "Salto %d: %@";
@@ -1022,7 +1022,7 @@
 // MARK: - Trace Path List Accessibility
 
 /* Location: TracePathListView.swift - Accessibility hint when trace is running */
-"contacts.trace.list.runningHint" = "O traçado está em curso";
+"contacts.trace.list.runningHint" = "A traçar a rota";
 
 // MARK: - Trace Path Cluster View
 
@@ -1046,39 +1046,39 @@
 /* Location: TracePathMapView.swift - Purpose: Hide labels accessibility */
 /* Location: TracePathMapView.swift - Purpose: Show labels accessibility */
 /* Location: TracePathMapView.swift - Purpose: Center on path accessibility */
-"contacts.trace.map.centerOnPath" = "Centrar no caminho";
+"contacts.trace.map.centerOnPath" = "Centrar na rota";
 
 /* Location: TracePathMapView.swift - Purpose: Save path alert title */
-"contacts.trace.map.saveTitle" = "Guardar caminho";
+"contacts.trace.map.saveTitle" = "Guardar rota";
 
 /* Location: TracePathMapView.swift - Purpose: Save path alert message */
-"contacts.trace.map.saveMessage" = "Introduza um nome para este caminho";
+"contacts.trace.map.saveMessage" = "Introduza um nome para esta rota";
 
 /* Location: TracePathMapView.swift - Purpose: Path name placeholder */
-"contacts.trace.map.pathName" = "Nome do caminho";
+"contacts.trace.map.pathName" = "Nome da rota";
 
 /* Location: TracePathMapView.swift - Purpose: Path saved alert title */
-"contacts.trace.map.savedTitle" = "Caminho guardado";
+"contacts.trace.map.savedTitle" = "Rota guardada";
 
 /* Location: TracePathMapView.swift - Purpose: Path saved alert message */
-"contacts.trace.map.savedMessage" = "O caminho foi guardado.";
+"contacts.trace.map.savedMessage" = "A rota foi guardada.";
 
 /* Location: TracePathMapView.swift - Purpose: Save failed alert title */
 "contacts.trace.map.saveFailedTitle" = "Falha ao guardar";
 
 /* Location: TracePathMapView.swift - Purpose: Save failed alert message */
-"contacts.trace.map.saveFailedMessage" = "Não foi possível guardar o caminho. Tente novamente.";
+"contacts.trace.map.saveFailedMessage" = "Não foi possível guardar a rota. Tente novamente.";
 
 /* Location: TracePathMapView.swift - Purpose: View results button */
 "contacts.trace.map.viewResults" = "Resultados";
 
 /* Location: TracePathMapViewModel.swift - Purpose: Default path name fallback */
-"contacts.trace.map.defaultPathName" = "Caminho";
+"contacts.trace.map.defaultPathName" = "Rota";
 
 // MARK: - Trace Results Sheet
 
 /* Location: TraceResultsSheet.swift - Purpose: Navigation title */
-"contacts.results.title" = "Resultados do traçado";
+"contacts.results.title" = "Resultados";
 
 /* Location: TraceResultsSheet.swift - Purpose: Dismiss button */
 "contacts.results.dismiss" = "Fechar";
@@ -1087,13 +1087,13 @@
 "contacts.results.batchSuccess" = "%d de %d bem-sucedidos (%d%%)";
 
 /* Location: TraceResultsSheet.swift - Purpose: Batch progress */
-"contacts.results.batchProgress" = "A executar o traçado %d de %d...";
+"contacts.results.batchProgress" = "A traçar %d de %d...";
 
 /* Location: TraceResultsSheet.swift - Purpose: Batch complete accessibility */
-"contacts.results.batchCompleteLabel" = "Lote concluído: %d de %d traçados bem-sucedidos (%d%%)";
+"contacts.results.batchCompleteLabel" = "Lote concluído: %d de %d tentativas bem-sucedidas (%d%%)";
 
 /* Location: TraceResultsSheet.swift - Purpose: Batch progress accessibility */
-"contacts.results.batchProgressLabel" = "Progresso do lote: traçado %d de %d";
+"contacts.results.batchProgressLabel" = "Progresso do lote: %d de %d";
 
 /* Location: TraceResultsSheet.swift - Purpose: Average round trip label */
 "contacts.results.avgRoundTrip" = "Ida e volta média";
@@ -1139,10 +1139,10 @@
 "contacts.results.partialDistanceHeader" = "Distância parcial";
 
 /* Location: TraceResultsSheet.swift - Purpose: Full path tip */
-"contacts.results.fullPathTip" = "Ative os serviços de localização ou defina uma localização para o dispositivo para ver a distância completa do caminho.";
+"contacts.results.fullPathTip" = "Ative os serviços de localização ou defina manualmente a localização do dispositivo, para ver a distância completa da rota.";
 
 /* Location: TraceResultsSheet.swift - Purpose: Full path section header */
-"contacts.results.fullPathHeader" = "Para incluir o caminho completo";
+"contacts.results.fullPathHeader" = "Para incluir a rota completa";
 
 /* Location: TraceResultsSheet.swift - Purpose: Partial distance accessibility label */
 "contacts.results.partialDistanceLabel" = "Distância parcial";
@@ -1151,7 +1151,7 @@
 "contacts.results.partialDistanceHint" = "Toque duas vezes para saber porque é que a localização do dispositivo está excluída";
 
 /* Location: TraceResultsSheet.swift - Purpose: Distance needs repeaters message */
-"contacts.results.needsRepeaters" = "O cálculo da distância exige pelo menos 2 repetidores no caminho.";
+"contacts.results.needsRepeaters" = "O cálculo da distância exige pelo menos 2 repetidores na rota.";
 
 /* Location: TraceResultsSheet.swift - Purpose: Distance error message */
 "contacts.results.distanceError" = "Não é possível calcular a distância. Todos os repetidores têm coordenadas, mas ocorreu um erro.";
@@ -1163,7 +1163,7 @@
 "contacts.results.repeatersWithoutLocations" = "Repetidores sem localização";
 
 /* Location: TraceResultsSheet.swift - Purpose: Save path button */
-"contacts.results.savePath" = "Guardar caminho";
+"contacts.results.savePath" = "Guardar rota";
 
 // MARK: - Trace Result Hop Row
 
@@ -1171,13 +1171,13 @@
 "contacts.results.hop.myDevice" = "O meu dispositivo";
 
 /* Location: TraceResultsSheet.swift - Purpose: Started trace label */
-"contacts.results.hop.started" = "Traçado iniciado";
+"contacts.results.hop.started" = "Início";
 
 /* Location: TraceResultsSheet.swift - Purpose: Received response label */
 "contacts.results.hop.received" = "Resposta recebida";
 
 /* Location: TraceResultsSheet.swift - Purpose: Repeated label */
-"contacts.results.hop.repeated" = "Repetido";
+"contacts.results.hop.repeated" = "Retransmitido";
 
 /* Location: TraceResultsSheet.swift - Purpose: Average SNR display */
 "contacts.results.hop.avgSNR" = "SNR médio: %@ dB (%@ – %@)";
@@ -1194,10 +1194,10 @@
 "contacts.trace.error.noResponse" = "Nenhuma resposta recebida";
 
 /* Location: TracePathViewModel.swift - Purpose: All traces failed error */
-"contacts.trace.error.allFailed" = "Todos os %d traçados falharam";
+"contacts.trace.error.allFailed" = "Falharam as %d tentativas";
 
 /* Location: TracePathViewModel.swift - Purpose: Send failed error */
-"contacts.trace.error.sendFailed" = "Falha ao enviar o pacote de traçado";
+"contacts.trace.error.sendFailed" = "Falha ao enviar o pacote";
 
 // MARK: - Stats Badge Accessibility
 
@@ -1205,24 +1205,24 @@
 // MARK: - Contact ViewModel Errors
 
 /* Location: ContactsViewModel.swift - Purpose: Delete requires connection error */
-"contacts.viewModel.connectToDelete" = "Ligue o dispositivo para eliminar nodos";
+"contacts.viewModel.connectToDelete" = "Ligue o dispositivo para eliminar nós";
 
 /* Location: ContactsViewModel.swift - Purpose: Delete radio command timed out error */
-"contacts.viewModel.removeTimedOut" = "A eliminação do nodo expirou. Tente novamente.";
+"contacts.viewModel.removeTimedOut" = "A eliminação do nó expirou. Tente novamente.";
 
 // MARK: - Path Management ViewModel Errors
 
 /* Location: PathManagementViewModel.swift - Purpose: Save path error prefix */
-"contacts.pathManagement.error.saveFailed" = "Falha ao guardar o caminho: %@";
+"contacts.pathManagement.error.saveFailed" = "Falha ao guardar a rota: %@";
 
 /* Location: PathManagementViewModel.swift - Purpose: Reset path error prefix */
-"contacts.pathManagement.error.resetFailed" = "Falha ao repor o caminho: %@";
+"contacts.pathManagement.error.resetFailed" = "Falha ao repor a rota: %@";
 
 /* Location: PathManagementViewModel.swift - Purpose: Set path error prefix */
-"contacts.pathManagement.error.setFailed" = "Falha ao definir o caminho: %@";
+"contacts.pathManagement.error.setFailed" = "Falha ao definir a rota: %@";
 
 /* Location: PathManagementViewModel.swift - Purpose: Shown when a stored path's hop can't be resized to the device's current hash size */
-"contacts.pathManagement.error.hopResizeRequired" = "O tamanho do hash do caminho mudou — remova e volte a adicionar os saltos para guardar.";
+"contacts.pathManagement.error.hopResizeRequired" = "O tamanho do hash da rota mudou. Remova e volte a adicionar os saltos para guardar.";
 
 /* Location: PathManagementViewModel.swift - Purpose: Shown when the existing path has more hops than the current hash mode supports */
 "contacts.pathManagement.error.tooManyHops" = "Demasiados saltos. O modo de hash atual suporta no máximo %d.";
@@ -1236,12 +1236,12 @@
 "contacts.codeInput.error.notFound" = "%@ não encontrado";
 
 /* Location: TracePathViewModel.swift - Purpose: Already in path error */
-"contacts.codeInput.error.alreadyInPath" = "%@ já está no caminho";
+"contacts.codeInput.error.alreadyInPath" = "%@ já está na rota";
 
 // MARK: - Path Name Generation
 
 /* Location: TracePathViewModel.swift - Purpose: Default path name prefix for hash-only paths */
-"contacts.pathName.prefix" = "Caminho %@";
+"contacts.pathName.prefix" = "Rota %@";
 
 /* Location: TracePathViewModel.swift - Purpose: Path name with two endpoints */
 "contacts.pathName.twoEndpoints" = "%@ → %@";

--- a/MC1/Resources/Localization/pt.lproj/Localizable.strings
+++ b/MC1/Resources/Localization/pt.lproj/Localizable.strings
@@ -15,7 +15,7 @@
 "common.cancel" = "Cancelar";
 
 /* Standard done button for completing an action */
-"common.done" = "OK";
+"common.done" = "Concluído";
 
 /* Standard save button for persisting changes */
 "common.save" = "Guardar";
@@ -37,13 +37,13 @@
 "common.error.networkError" = "Erro de rede: %@";
 
 /* Invalid response from API */
-"common.error.invalidResponse" = "Resposta inválida da API de elevação";
+"common.error.invalidResponse" = "Resposta inválida da API de altitude";
 
 /* API error with message - %@ is the error message */
 "common.error.apiError" = "Erro de API: %@";
 
 /* No data returned from API */
-"common.error.noElevationData" = "Não foram devolvidos dados de elevação";
+"common.error.noElevationData" = "Não foram devolvidos dados de altitude";
 
 /* Rate limited by elevation API */
 "common.error.rateLimited" = "Demasiados pedidos. Tente novamente dentro de instantes.";
@@ -66,13 +66,13 @@
 // MARK: - Tab Bar
 
 /* Tab bar title for the messaging/conversations screen */
-"tabs.chats" = "Chats";
+"tabs.chats" = "Conversas";
 
 /* VoiceOver value announcing the unread message count on the Chats sidebar icon. %d is the count. */
 "tabs.chatsUnreadAccessibilityValue" = "%d por ler";
 
 /* Tab bar title for the nodes/contacts list screen */
-"tabs.nodes" = "Nodos";
+"tabs.nodes" = "Nós";
 
 /* Tab bar title for the map screen showing node locations */
 "tabs.map" = "Mapa";
@@ -98,7 +98,7 @@
 "alert.connectionFailed.defaultMessage" = "Não foi possível ligar ao dispositivo.";
 
 /* Message suggesting another app may be connected to the device */
-"alert.couldNotConnect.otherAppMessage" = "Certifique-se de que nenhum outro app está ligado ao dispositivo e tente novamente.";
+"alert.couldNotConnect.otherAppMessage" = "Certifique-se de que nenhuma app está ligada ao dispositivo e tente novamente.";
 
 /* Button to remove failed pairing and retry connection */
 "alert.connectionFailed.removeAndRetry" = "Remover e tentar novamente";
@@ -173,7 +173,7 @@
 "notifications.quickReplyFailed.title" = "Mensagem não enviada";
 
 /* Notification body when a quick reply fails - %@ is the contact or channel name */
-"notifications.quickReplyFailed.body" = "A resposta para %@ não pôde ser enviada.";
+"notifications.quickReplyFailed.body" = "Não foi possível enviar a resposta para %@.";
 
 /* Fallback display name for a discovered contact with no advertised name */
 "notifications.discovery.unknownContact" = "Contacto desconhecido";
@@ -187,7 +187,7 @@
 "accessibility.connection.deviceConnectionLost" = "Ligação ao dispositivo perdida";
 
 /* VoiceOver announcement when device reconnects */
-"accessibility.connection.deviceReconnected" = "Dispositivo religado";
+"accessibility.connection.deviceReconnected" = "Ligação restabelecida";
 
 /* VoiceOver signal-strength descriptors for the device picker signal bars */
 "accessibility.signalStrength.weak" = "Sinal fraco";
@@ -208,7 +208,7 @@
 "error.meshCore.parseError" = "Falha ao analisar a resposta do dispositivo: %@";
 
 /* Location: MeshCoreError+UserFacingMessage.swift - No active connection to the radio */
-"error.meshCore.notConnected" = "Não ligado ao dispositivo.";
+"error.meshCore.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: MeshCoreError+UserFacingMessage.swift - A command failed on the device - %@ is the failure reason */
 "error.meshCore.commandFailed" = "O comando falhou: %@";
@@ -295,10 +295,10 @@
 "error.ble.connectionTimeout" = "A ligação expirou. Tente novamente.";
 
 /* Location: BLEError+UserFacingMessage.swift - No BLE device connected */
-"error.ble.notConnected" = "Não ligado a um dispositivo.";
+"error.ble.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: BLEError+UserFacingMessage.swift - Required BLE characteristic missing */
-"error.ble.characteristicNotFound" = "Não foi possível comunicar com o dispositivo. Tente religar.";
+"error.ble.characteristicNotFound" = "Não foi possível comunicar com o dispositivo. Tente restabelecer a ligação.";
 
 /* Location: BLEError+UserFacingMessage.swift - BLE write failed - %@ is the failure detail */
 "error.ble.writeError" = "Falha ao enviar dados: %@";
@@ -316,7 +316,7 @@
 "error.ble.pairingFailed" = "Falha no emparelhamento Bluetooth: %@";
 
 /* Location: BLEError+UserFacingMessage.swift - Radio already in use by another app */
-"error.ble.deviceConnectedToOtherApp" = "Este dispositivo está ligado a outro app. Apenas um app pode usar um rádio mesh de cada vez para evitar problemas de comunicação.";
+"error.ble.deviceConnectedToOtherApp" = "Este dispositivo está ligado a outra app. Apenas uma app pode usar um rádio mesh de cada vez para evitar problemas de comunicação.";
 
 /* Location: ConnectionError+UserFacingMessage.swift - Connection failed - %@ is the failure reason */
 "error.connection.connectionFailed" = "Falha na ligação: %@";
@@ -325,7 +325,7 @@
 "error.connection.deviceNotFound" = "Dispositivo não encontrado";
 
 /* Location: ConnectionError+UserFacingMessage.swift - No active device connection */
-"error.connection.notConnected" = "Não ligado ao dispositivo";
+"error.connection.notConnected" = "Sem ligação ao dispositivo";
 
 /* Location: ConnectionError+UserFacingMessage.swift - Post-connect device initialization failed - %@ is the failure reason */
 "error.connection.initializationFailed" = "Falha na inicialização do dispositivo: %@";
@@ -337,7 +337,7 @@
 "error.wifi.connectionTimeout" = "A ligação expirou. Verifique o hostname ou o endereço IP e certifique-se de que o dispositivo está acessível.";
 
 /* Location: WiFiTransportError+UserFacingMessage.swift - No active WiFi connection */
-"error.wifi.notConnected" = "Não ligado ao dispositivo.";
+"error.wifi.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: WiFiTransportError+UserFacingMessage.swift - WiFi send failed - %@ is the failure reason */
 "error.wifi.sendFailed" = "Falha ao enviar dados: %@";
@@ -358,7 +358,7 @@
 "error.accessorySetup.sessionNotActive" = "O Bluetooth não está pronto. Certifique-se de que o Bluetooth está ativado e tente novamente.";
 
 /* Location: AccessorySetupKitError+UserFacingMessage.swift - AccessorySetupKit session invalidated */
-"error.accessorySetup.sessionInvalidated" = "A sessão Bluetooth terminou inesperadamente. Reinicie o app.";
+"error.accessorySetup.sessionInvalidated" = "A sessão Bluetooth terminou inesperadamente. Reinicie a app.";
 
 /* Location: AccessorySetupKitError+UserFacingMessage.swift - User dismissed the accessory picker */
 "error.accessorySetup.pickerDismissed" = "A seleção do dispositivo foi cancelada.";
@@ -382,7 +382,7 @@
 "error.accessorySetup.connectionFailed" = "Não foi possível ligar ao dispositivo. Tente novamente.";
 
 /* Location: ContactServiceError+UserFacingMessage.swift - No active connection to the radio */
-"error.contactService.notConnected" = "Não ligado ao rádio";
+"error.contactService.notConnected" = "Sem ligação ao rádio";
 
 /* Location: ContactServiceError+UserFacingMessage.swift - Contact operation message failed to send */
 "error.contactService.sendFailed" = "Falha ao enviar mensagem";
@@ -397,13 +397,13 @@
 "error.contactService.contactNotFound" = "Contacto não encontrado no dispositivo";
 
 /* Location: ContactServiceError+UserFacingMessage.swift - Radio node list has no free slots */
-"error.contactService.contactTableFull" = "A lista de nodos do dispositivo está cheia";
+"error.contactService.contactTableFull" = "A lista de nós do dispositivo está cheia";
 
 /* Location: ContactServiceError+UserFacingMessage.swift - Node advertisement missing or stale, so the node cannot be shared */
-"error.contactService.shareContactUnavailable" = "Não foi possível partilhar o nodo. O Advert do nodo pode estar em falta ou desatualizado.";
+"error.contactService.shareContactUnavailable" = "Não foi possível partilhar o nó. O Advert do nó pode estar em falta ou desatualizado.";
 
 /* Location: MessageServiceError+UserFacingMessage.swift - No active connection to the radio */
-"error.messageService.notConnected" = "Não ligado ao dispositivo.";
+"error.messageService.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: MessageServiceError+UserFacingMessage.swift - Recipient contact missing from the database */
 "error.messageService.contactNotFound" = "Contacto não encontrado.";
@@ -421,7 +421,7 @@
 "error.messageService.messageTooLong" = "A mensagem excede o comprimento máximo permitido.";
 
 /* Location: ChannelServiceError+UserFacingMessage.swift - No active connection to the radio */
-"error.channelService.notConnected" = "Não ligado ao dispositivo.";
+"error.channelService.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: ChannelServiceError+UserFacingMessage.swift - Channel missing from the database */
 "error.channelService.channelNotFound" = "Canal não encontrado.";
@@ -463,16 +463,16 @@
 "error.chatSendQueue.persistFailed" = "Falha ao colocar a mensagem na fila de envio: %@";
 
 /* Location: ChatSendQueueServiceError+UserFacingMessage.swift - No active connection to the radio */
-"error.chatSendQueue.notConnected" = "Não ligado ao dispositivo.";
+"error.chatSendQueue.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: MessagePollingError+UserFacingMessage.swift - No active connection to the radio */
-"error.messagePolling.notConnected" = "Não ligado ao dispositivo.";
+"error.messagePolling.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: MessagePollingError+UserFacingMessage.swift - Fetching queued messages from the radio failed */
 "error.messagePolling.pollingFailed" = "Falha ao obter as mensagens em espera.";
 
 /* Location: AdvertisementError+UserFacingMessage.swift - No active connection to the radio */
-"error.advertisement.notConnected" = "Não ligado ao dispositivo.";
+"error.advertisement.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: AdvertisementError+UserFacingMessage.swift - Self-advertisement broadcast failed */
 "error.advertisement.sendFailed" = "Falha ao enviar o Advert.";
@@ -481,7 +481,7 @@
 "error.advertisement.invalidResponse" = "Resposta inválida do dispositivo.";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - No active connection to the mesh radio */
-"error.remoteNode.notConnected" = "Não ligado ao dispositivo mesh";
+"error.remoteNode.notConnected" = "Sem ligação ao dispositivo mesh";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - Remote node login failed */
 "error.remoteNode.loginFailed" = "Falha ao iniciar sessão.";
@@ -490,7 +490,7 @@
 "error.remoteNode.sendFailed" = "Falha no envio.";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - Malformed response from the remote node */
-"error.remoteNode.invalidResponse" = "Resposta inválida do nodo remoto";
+"error.remoteNode.invalidResponse" = "Resposta inválida do nó remoto";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - Remote node rejected the operation */
 "error.remoteNode.permissionDenied" = "Permissão recusada";
@@ -499,16 +499,16 @@
 "error.remoteNode.timeout" = "O pedido expirou";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - No stored session for the remote node */
-"error.remoteNode.sessionNotFound" = "Sessão do nodo remoto não encontrada";
+"error.remoteNode.sessionNotFound" = "Sessão do nó remoto não encontrada";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - Saved password missing from the keychain */
 "error.remoteNode.passwordNotFound" = "Palavra-passe não encontrada no Porta-chaves";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - Keep-alive needs a direct path but the route is flood-routed */
-"error.remoteNode.floodRouted" = "O keep-alive requer um caminho de encaminhamento direto";
+"error.remoteNode.floodRouted" = "O keep-alive requer uma rota de encaminhamento direto";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - Establishing a direct path to the node failed */
-"error.remoteNode.pathDiscoveryFailed" = "Falha ao estabelecer um caminho direto";
+"error.remoteNode.pathDiscoveryFailed" = "Falha ao estabelecer uma rota direta";
 
 /* Location: RemoteNodeError+UserFacingMessage.swift - Remote node contact missing from the database */
 "error.remoteNode.contactNotFound" = "Contacto não encontrado na base de dados";
@@ -520,7 +520,7 @@
 "error.remoteNode.cancelled" = "Início de sessão cancelado";
 
 /* Location: RoomServerError+UserFacingMessage.swift - No active connection to the radio */
-"error.roomServer.notConnected" = "Não ligado ao dispositivo.";
+"error.roomServer.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: RoomServerError+UserFacingMessage.swift - No stored session for the room server */
 "error.roomServer.sessionNotFound" = "Sessão da sala não encontrada.";
@@ -535,7 +535,7 @@
 "error.roomServer.invalidResponse" = "Resposta inválida do dispositivo.";
 
 /* Location: BinaryProtocolError+UserFacingMessage.swift - No active connection to the radio */
-"error.binaryProtocol.notConnected" = "Não ligado ao dispositivo.";
+"error.binaryProtocol.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: BinaryProtocolError+UserFacingMessage.swift - Binary request failed to send */
 "error.binaryProtocol.sendFailed" = "Falha ao enviar o pedido.";
@@ -559,7 +559,7 @@
 "error.persistence.channelNotFound" = "Canal não encontrado.";
 
 /* Location: PersistenceStoreError+UserFacingMessage.swift - Remote node session row missing from the database */
-"error.persistence.remoteNodeSessionNotFound" = "Sessão do nodo remoto não encontrada.";
+"error.persistence.remoteNodeSessionNotFound" = "Sessão do nó remoto não encontrada.";
 
 /* Location: PersistenceStoreError+UserFacingMessage.swift - Database save failed - %@ is the failure reason */
 "error.persistence.saveFailed" = "Falha ao guardar: %@";
@@ -571,7 +571,7 @@
 "error.persistence.invalidData" = "Dados inválidos.";
 
 /* Location: SyncCoordinatorError+UserFacingMessage.swift - No active connection to the radio */
-"error.syncCoordinator.notConnected" = "Não ligado ao dispositivo.";
+"error.syncCoordinator.notConnected" = "Sem ligação ao dispositivo.";
 
 /* Location: SyncCoordinatorError+UserFacingMessage.swift - Full sync failed - %@ is the failure reason */
 "error.syncCoordinator.syncFailed" = "Falha na sincronização: %@";

--- a/MC1/Resources/Localization/pt.lproj/Map.strings
+++ b/MC1/Resources/Localization/pt.lproj/Map.strings
@@ -9,7 +9,7 @@
 // MARK: - Common
 
 /* Location: MapView.swift - Purpose: Done button for sheets */
-"map.common.done" = "OK";
+"map.common.done" = "Concluído";
 
 // MARK: - Map Controls
 
@@ -93,16 +93,16 @@
 "map.detail.longitude" = "Longitude";
 
 /* Location: MapView.swift ContactDetailSheet - Purpose: Section header for outbound path info */
-"map.detail.section.outboundPath" = "Caminho de saída";
+"map.detail.section.outboundPath" = "Rota de saída";
 
 /* Location: MapView.swift ContactDetailSheet - Purpose: Label for routing type */
 "map.detail.routing" = "Encaminhamento";
 
 /* Location: MapView.swift ContactDetailSheet - Purpose: Flood routing type value */
-"map.detail.routingFlood" = "Flood";
+"map.detail.routingFlood" = "Difusão";
 
 /* Location: MapView.swift ContactDetailSheet - Purpose: Label for path length */
-"map.detail.pathLength" = "Comprimento do caminho";
+"map.detail.pathLength" = "Comprimento da rota";
 
 /* Location: MapView.swift ContactDetailSheet - Purpose: Path length value with hop count */
 "map.detail.hops" = "%d saltos";
@@ -163,13 +163,13 @@
 "map.callout.discovered" = "Descoberto";
 
 /* Location: DiscoveredNodeDetailSheet.swift - Purpose: Navigation title for discovered node detail */
-"map.discoveredDetail.title" = "Nodo descoberto";
+"map.discoveredDetail.title" = "Nó descoberto";
 
 /* Location: DiscoveredNodeDetailSheet.swift - Purpose: Primary action to add discovered node to the radio table */
-"map.discoveredDetail.add" = "Adicionar aos nodos";
+"map.discoveredDetail.add" = "Adicionar aos nós";
 
 /* Location: DiscoveredNodeCalloutContent.swift - Purpose: Accessibility label for discovered pins */
-"map.pin.accessibility.discovered" = "Descoberto, não está na lista de nodos";
+"map.pin.accessibility.discovered" = "Descoberto, não está na lista de nós";
 
 // MARK: - Contact Annotation
 

--- a/MC1/Resources/Localization/pt.lproj/Onboarding.strings
+++ b/MC1/Resources/Localization/pt.lproj/Onboarding.strings
@@ -25,13 +25,13 @@
 "permissions.title" = "Algumas permissões";
 
 /* Location: PermissionsView.swift - Subtitle encouraging notification permission */
-"permissions.subtitle" = "As duas são opcionais. É possível mudar de ideia em Definições a qualquer momento.";
+"permissions.subtitle" = "As duas são opcionais. É possível mudar de ideias nas Definições a qualquer momento.";
 
 /* Location: PermissionsView.swift - Permission card title for notifications */
 "permissions.notifications.title" = "Notificações";
 
 /* Location: PermissionsView.swift - Permission card description for notifications */
-"permissions.notifications.description" = "Receba alertas de novas mensagens e bateria fraca, mesmo com o app fechado.";
+"permissions.notifications.description" = "Receba alertas de novas mensagens e bateria fraca, mesmo com a app fechada.";
 
 /* Location: PermissionsView.swift - Permission card title for location */
 "permissions.location.title" = "Localização";
@@ -67,7 +67,7 @@
 "deviceScan.title" = "Emparelhe o dispositivo";
 
 /* Location: DeviceScanView.swift - Subtitle with pairing instructions */
-"deviceScan.subtitle" = "Ligue a alimentação do rádio, desligue-o de todas as outras apps e dispositivos e toque em Adicionar dispositivo.";
+"deviceScan.subtitle" = "Ligue o rádio, desemparelhe-o de todas as outras apps e dispositivos e toque em Adicionar dispositivo.";
 
 /* Location: DeviceScanView.swift - Message shown when device is already paired */
 "deviceScan.alreadyPaired" = "O dispositivo já está emparelhado";
@@ -91,7 +91,7 @@
 "deviceScan.addDevice" = "Adicionar dispositivo";
 
 /* Location: DeviceScanView.swift - Button to retry connection after other-app conflict */
-"deviceScan.retryConnection" = "Tentar ligação novamente";
+"deviceScan.retryConnection" = "Tentar ligar novamente";
 
 /* Location: DeviceScanView.swift - Button for troubleshooting */
 "deviceScan.deviceNotAppearing" = "Ajuda";
@@ -106,8 +106,8 @@
 "deviceScan.demoModeAlert.message" = "Agora é possível continuar sem um dispositivo. Ative ou desative o modo demo em Definições a qualquer momento.";
 
 /* Location: ConnectionUIState.presentPairingFailure(_:) - Pairing failure alert messages */
-"deviceScan.error.authenticationFailed" = "O emparelhamento guardado com este rádio deixou de funcionar. Toque em Remover e tentar novamente para emparelhar de novo no app; o rádio pode mostrar um novo código de emparelhamento.";
-"deviceScan.error.pinRejected" = "O PIN não foi aceite. Verifique o PIN mostrado no dispositivo e tente novamente. Primeiro, o iOS pede a confirmação da remoção do emparelhamento que falhou.";
+"deviceScan.error.authenticationFailed" = "O emparelhamento guardado com este rádio deixou de funcionar. Toque em Remover e tentar novamente para emparelhar de novo na app; o rádio pode mostrar um novo código de emparelhamento.";
+"deviceScan.error.pinRejected" = "O PIN não foi aceite. Verifique o PIN mostrado no dispositivo e tente novamente. O iOS vai primeiro pedir para confirmar a remoção do emparelhamento anterior.";
 "deviceScan.error.connectionFailed" = "Não foi possível ligar ao dispositivo. Tente novamente ou remova-o se o problema continuar.";
 
 // MARK: - Troubleshooting Sheet
@@ -131,13 +131,13 @@
 "troubleshooting.basicChecks.restart" = "Reinicie o dispositivo MeshCore";
 
 /* Location: DeviceScanView.swift - Section header for factory reset help */
-"troubleshooting.factoryReset.header" = "Repor o dispositivo para os valores de fábrica?";
+"troubleshooting.factoryReset.header" = "Repor o dispositivo para as definições de fábrica?";
 
 /* Location: DeviceScanView.swift - Explanation about stale pairings */
-"troubleshooting.factoryReset.explanation" = "Se o dispositivo MeshCore for reposto para os valores de fábrica, o iOS ainda pode ter o emparelhamento antigo. Limpar isto em Definições do sistema permite que o dispositivo volte a aparecer.";
+"troubleshooting.factoryReset.explanation" = "Se o dispositivo MeshCore for reposto para as definições de fábrica, o iOS ainda pode ter o emparelhamento antigo. Limpar isto em Definições do sistema permite que o dispositivo volte a aparecer.";
 
 /* Location: DeviceScanView.swift - Additional explanation about removal confirmation */
-"troubleshooting.factoryReset.confirmationNote" = "Ao tocar abaixo, será necessário confirmar a remoção do emparelhamento antigo. Isto é normal — permite que o dispositivo reposto volte a aparecer.";
+"troubleshooting.factoryReset.confirmationNote" = "Ao tocar abaixo, terá de confirmar a remoção do emparelhamento antigo. Isto é normal: permite que o dispositivo reposto volte a aparecer.";
 
 /* Location: DeviceScanView.swift - Button to clear previous pairing */
 "troubleshooting.factoryReset.clearPairing" = "Limpar emparelhamento anterior";
@@ -167,7 +167,7 @@
 "troubleshooting.stillNotAppearing.header" = "Ainda não aparece?";
 
 /* Location: TroubleshootingSheet.swift - Body text explaining backup and reflash steps */
-"troubleshooting.stillNotAppearing.body" = "Se já tentou tudo acima, faça uma cópia de segurança da configuração do rádio no app MeshCore de Liam Cottle e depois apague o rádio e volte a gravar o firmware no computador em https://flasher.meshcore.io";
+"troubleshooting.stillNotAppearing.body" = "Se já tentou tudo acima, faça uma cópia de segurança da configuração do rádio na app MeshCore de Liam Cottle e depois apague e volte a instalar o firmware a partir do computador em https://flasher.meshcore.io";
 
 
 // MARK: - Mesh Animation View
@@ -182,7 +182,7 @@
 "noDevice.sheet.title" = "Dê uma vista de olhos";
 
 /* Location: NoDeviceSheet.swift - Sheet body */
-"noDevice.sheet.body" = "É necessário um rádio emparelhado para enviar e receber mensagens. Explore o app por agora e emparelhe a qualquer momento em Definições.";
+"noDevice.sheet.body" = "É necessário um rádio emparelhado para enviar e receber mensagens. Explore a app por agora e emparelhe a qualquer momento em Definições.";
 
 /* Location: NoDeviceSheet.swift - Primary CTA */
 "noDevice.sheet.confirm" = "Continuar";
@@ -203,7 +203,7 @@
 "preset.subtitle.locale" = "Escolha uma predefinição para o rádio.";
 
 /* Location: PresetStepView.swift - Footer help line pointing users to the MeshCore Discord */
-"preset.discordHelp" = "Não sabe qual predefinição escolher? Entre no Discord oficial do MeshCore e pergunte! [https://meshcore.gg](https://meshcore.gg)";
+"preset.discordHelp" = "Não sabe que predefinição escolher? Entre no Discord oficial do MeshCore e pergunte! [https://meshcore.gg](https://meshcore.gg)";
 
 /* Location: PresetStepView.swift - Apply CTA "Use %@" */
 "preset.use" = "Usar %@";
@@ -215,7 +215,7 @@
 "preset.alreadyConfigured.subtitle" = "O rádio já está em %@, a predefinição recomendada para %@.";
 
 /* Location: PresetStepView.swift - Already-configured primary CTA */
-"preset.alreadyConfigured.done" = "OK";
+"preset.alreadyConfigured.done" = "Concluído";
 
 /* Location: PresetStepView.swift - Already-configured secondary link */
 "preset.alreadyConfigured.choose" = "Escolher outra predefinição";
@@ -277,7 +277,7 @@
 "region.title" = "Escolha a região";
 
 /* Location: RegionStepView.swift - Subtitle for the region step */
-"region.subtitle" = "Serão mostradas predefinições que funcionam na sua área.";
+"region.subtitle" = "Só aparecem as predefinições que funcionam na sua área.";
 
 /* Location: RegionStepView.swift - "Detected" tag */
 "region.detected.tag" = "Detetada";
@@ -298,7 +298,7 @@
 "region.resolving" = "A procurar a região…";
 
 /* Location: RegionStepView.swift - Error shown when user-initiated retry of "Use my location" cannot resolve a region */
-"region.useMyLocation.failure" = "A pesquisa de localização não devolveu uma região. Escolha manualmente abaixo.";
+"region.useMyLocation.failure" = "Não foi possível determinar a região a partir da sua localização. Escolha manualmente abaixo.";
 
 
 // MARK: - Device Scanner Sheet (macOS)

--- a/MC1/Resources/Localization/pt.lproj/RemoteNodes.strings
+++ b/MC1/Resources/Localization/pt.lproj/RemoteNodes.strings
@@ -18,7 +18,7 @@
 "remoteNodes.auth.cancel" = "Cancelar";
 
 /* Location: NodeAuthenticationSheet.swift - Node details section header */
-"remoteNodes.auth.nodeDetails" = "Detalhes do nodo";
+"remoteNodes.auth.nodeDetails" = "Detalhes do nó";
 
 /* Location: NodeAuthenticationSheet.swift - Name label */
 "remoteNodes.auth.name" = "Nome";
@@ -57,24 +57,24 @@
 "remoteNodes.auth.connect" = "Ligar";
 
 /* Location: NodeAuthenticationSheet.swift - Path section header */
-"remoteNodes.auth.path" = "Caminho";
+"remoteNodes.auth.path" = "Rota";
 
 /* Location: NodeAuthenticationSheet.swift - Flood routing toggle */
-"remoteNodes.auth.floodRouting" = "Encaminhamento Flood";
-"remoteNodes.auth.floodRetryStatus" = "Sem resposta pelo caminho conhecido. A tentar novamente com encaminhamento flood.";
-"remoteNodes.auth.floodFooter" = "O encaminhamento flood é mais lento e usa mais tempo no ar da rede. Utilize-o quando o caminho conhecido não funcionar a partir da localização atual. Um novo caminho é aprendido automaticamente após iniciar sessão.";
+"remoteNodes.auth.floodRouting" = "Encaminhamento por difusão";
+"remoteNodes.auth.floodRetryStatus" = "Sem resposta pela rota conhecida. A tentar novamente com encaminhamento por difusão.";
+"remoteNodes.auth.floodFooter" = "O encaminhamento por difusão é mais lento e usa mais tempo de antena da rede. Utilize-o quando a rota conhecida não funcionar a partir da localização atual. Uma nova rota é aprendida automaticamente após iniciar sessão.";
 
 /* Location: NodeAuthenticationSheet.swift - Path section footer when stored path exists */
-"remoteNodes.auth.pathFooter" = "Utilize o caminho conhecido até este nodo, ou mude para o encaminhamento flood para que a rede encontre um caminho.";
+"remoteNodes.auth.pathFooter" = "Utilize a rota conhecida até este nó, ou mude para o encaminhamento por difusão e deixe que a rede encontre outra.";
 
 /* Location: NodeAuthenticationSheet.swift - Path hop whose repeater is not known */
 "remoteNodes.auth.pathHopUnknown" = "<desconhecido>";
 
 /* Location: NodeAuthenticationSheet.swift - Label when no route is set */
-"remoteNodes.auth.noRouteSet" = "Nenhum caminho definido";
+"remoteNodes.auth.noRouteSet" = "Nenhuma rota definida";
 
 /* Location: NodeAuthenticationSheet.swift - Path section footer when no route is set */
-"remoteNodes.auth.noRouteFooter" = "Nenhum caminho conhecido até este nodo. A rede irá encontrar um caminho automaticamente.";
+"remoteNodes.auth.noRouteFooter" = "Nenhuma rota conhecida até este nó. A rede irá encontrar uma automaticamente.";
 
 /* Location: NodeAuthenticationSheet.swift - Accessibility announcement for countdown */
 "remoteNodes.auth.secondsRemainingAnnouncement" = "%d segundos restantes";
@@ -85,7 +85,7 @@
 "remoteNodes.settings.title" = "Definições do repetidor";
 
 /* Location: RepeaterSettingsView.swift - Done button (used in multiple places) */
-"remoteNodes.settings.done" = "OK";
+"remoteNodes.settings.done" = "Concluído";
 
 /* Location: NodeSettingsView.swift - Settings tab label */
 "remoteNodes.settings.tab.settings" = "Definições";
@@ -139,10 +139,10 @@
 "remoteNodes.settings.bandwidthKHz" = "Largura de banda (kHz)";
 
 /* Location: RepeaterSettingsView.swift - Accessibility label for bandwidth picker options - %@ is formatted bandwidth */
-"remoteNodes.settings.accessibility.bandwidthLabel" = "%@ quilohertz";
+"remoteNodes.settings.accessibility.bandwidthLabel" = "%@ kilohertz";
 
 /* Location: RepeaterSettingsView.swift - Bandwidth accessibility hint */
-"remoteNodes.settings.bandwidthHint" = "Valores mais baixos aumentam o alcance, mas diminuem a velocidade";
+"remoteNodes.settings.bandwidthHint" = "Valores menores aumentam o alcance, mas diminuem a velocidade";
 
 /* Location: RepeaterSettingsView.swift - Spreading factor label */
 "remoteNodes.settings.spreadingFactor" = "Fator de espalhamento";
@@ -151,7 +151,7 @@
 "remoteNodes.settings.accessibility.spreadingFactorLabel" = "Fator de espalhamento %d";
 
 /* Location: RepeaterSettingsView.swift - Spreading factor accessibility hint */
-"remoteNodes.settings.spreadingFactorHint" = "Valores mais altos aumentam o alcance, mas diminuem a velocidade";
+"remoteNodes.settings.spreadingFactorHint" = "Valores maiores aumentam o alcance, mas diminuem a velocidade";
 
 /* Location: RepeaterSettingsView.swift - Coding rate label */
 "remoteNodes.settings.codingRate" = "Taxa de codificação";
@@ -160,7 +160,7 @@
 "remoteNodes.settings.accessibility.codingRateLabel" = "Taxa de codificação %d";
 
 /* Location: RepeaterSettingsView.swift - Coding rate accessibility hint */
-"remoteNodes.settings.codingRateHint" = "Valores mais altos adicionam correção de erros, mas diminuem a velocidade";
+"remoteNodes.settings.codingRateHint" = "Valores maiores adicionam correção de erros, mas diminuem a velocidade";
 
 /* Location: RepeaterSettingsView.swift - TX power label */
 "remoteNodes.settings.txPowerDbm" = "Potência TX (dBm)";
@@ -195,7 +195,7 @@
 "remoteNodes.settings.contactInfoPlaceholder" = "Frequência, nome do operador, sítio web...";
 
 /* Location: RepeaterSettingsView.swift - Contact info footer */
-"remoteNodes.settings.contactInfoFooter" = "Dados de contacto públicos visíveis para outros nodos. Utilize quebras de linha para separar os campos.";
+"remoteNodes.settings.contactInfoFooter" = "Dados de contacto públicos visíveis para outros nós. Utilize quebras de linha para separar os campos.";
 
 /* Location: RepeaterSettingsView.swift - Apply contact info button */
 "remoteNodes.settings.applyContactInfo" = "Aplicar informações de contacto";
@@ -214,13 +214,13 @@
 "remoteNodes.settings.min" = "min";
 
 /* Location: RepeaterSettingsView.swift - Advert interval (flood) label */
-"remoteNodes.settings.advertIntervalFlood" = "Intervalo de Advert (flood)";
+"remoteNodes.settings.advertIntervalFlood" = "Intervalo de Advert (difusão)";
 
 /* Location: RepeaterSettingsView.swift - Hours unit */
 "remoteNodes.settings.hrs" = "h";
 
 /* Location: RepeaterSettingsView.swift - Max flood hops label */
-"remoteNodes.settings.maxFloodHops" = "Máximo de saltos Flood";
+"remoteNodes.settings.maxFloodHops" = "Máximo de saltos por difusão";
 
 /* Location: RepeaterSettingsView.swift - Hops unit */
 "remoteNodes.settings.hops" = "saltos";
@@ -253,7 +253,7 @@
 "remoteNodes.settings.identityFooter" = "Nome do repetidor e coordenadas GPS para apresentação no mapa.";
 
 /* Location: RepeaterSettingsView.swift - Behavior section footer */
-"remoteNodes.settings.behaviorFooter" = "Intervalos de Advert, saltos flood e modo repetidor.";
+"remoteNodes.settings.behaviorFooter" = "Intervalos de Advert, saltos por difusão e modo repetidor.";
 
 /* Location: RepeaterSettingsView.swift - Device actions section header */
 "remoteNodes.settings.deviceActions" = "Ações do dispositivo";
@@ -350,10 +350,10 @@
 "remoteNodes.settings.regionsFooter" = "Guarde no repetidor para manter as alterações após os reinícios.";
 
 /* Location: RepeaterSettingsView.swift - Unscoped region display name */
-"remoteNodes.settings.regions.allTraffic" = "Sem âmbito";
+"remoteNodes.settings.regions.allTraffic" = "Sem scope";
 
 /* Location: RepeaterSettingsView.swift - Unscoped region with asterisk display */
-"remoteNodes.settings.regions.allTrafficWildcard" = "* (Sem âmbito)";
+"remoteNodes.settings.regions.allTrafficWildcard" = "* (Sem scope)";
 
 /* Location: RepeaterSettingsView.swift - Home region picker label */
 "remoteNodes.settings.regions.homeRegion" = "Região home";
@@ -361,7 +361,7 @@
 /* Location: RepeaterSettingsView.swift - No home region set */
 /* Location: RepeaterSettingsView.swift - Toggle label for flood allow per region */
 /* Location: RepeaterSettingsView.swift - Accessibility hint for flood toggle */
-"remoteNodes.settings.regions.floodToggleHint" = "Quando desligado, os pacotes flood desta região são descartados";
+"remoteNodes.settings.regions.floodToggleHint" = "Quando desligado, os pacotes por difusão desta região são descartados";
 
 /* Location: RepeaterSettingsView.swift - Add region button */
 "remoteNodes.settings.regions.addRegion" = "Adicionar região";
@@ -410,8 +410,8 @@
 
 /* Location: RepeaterStatusView.swift - Guest mode badge in header */
 "remoteNodes.status.guestMode" = "Modo convidado";
-"remoteNodes.status.clockAhead" = "O relógio deste nodo está %@ adiantado em relação ao seu rádio. Um nodo com o relógio impreciso pode ignorar comandos ou mostrar horas de mensagem erradas.";
-"remoteNodes.status.clockBehind" = "O relógio deste nodo está %@ atrasado em relação ao seu rádio. Um nodo com o relógio impreciso pode ignorar comandos ou mostrar horas de mensagem erradas.";
+"remoteNodes.status.clockAhead" = "O relógio deste nó está %@ adiantado em relação ao seu rádio. Um nó com o relógio impreciso pode ignorar comandos ou mostrar horas erradas nas mensagens.";
+"remoteNodes.status.clockBehind" = "O relógio deste nó está %@ atrasado em relação ao seu rádio. Um nó com o relógio impreciso pode ignorar comandos ou mostrar horas erradas nas mensagens.";
 
 /* Location: RepeaterStatusView.swift - Owner info section label */
 "remoteNodes.status.ownerInfo" = "Informações de contacto";
@@ -432,10 +432,10 @@
 "remoteNodes.status.uptime" = "Tempo de atividade";
 
 /* Location: SharedNodeViews.swift - Airtime label */
-"remoteNodes.status.airtime" = "Tempo no ar";
+"remoteNodes.status.airtime" = "Tempo de antena";
 
 /* Location: SharedNodeViews.swift - Airtime percent label */
-"remoteNodes.status.airtimePercent" = "Tempo no ar %%";
+"remoteNodes.status.airtimePercent" = "Tempo de antena %%";
 
 /* Location: RepeaterStatusView.swift - Last RSSI label */
 "remoteNodes.status.lastRssi" = "Último RSSI";
@@ -459,11 +459,11 @@
 /* Location: SharedNodeStatusViews.swift - Sent (direct) packets label */
 "remoteNodes.status.sentDirect" = "Enviados (direto)";
 /* Location: SharedNodeStatusViews.swift - Sent (flood) packets label */
-"remoteNodes.status.sentFlood" = "Enviados (Flood)";
+"remoteNodes.status.sentFlood" = "Enviados (Difusão)";
 /* Location: SharedNodeStatusViews.swift - Received (direct) packets label */
 "remoteNodes.status.receivedDirect" = "Recebidos (direto)";
 /* Location: SharedNodeStatusViews.swift - Received (flood) packets label */
-"remoteNodes.status.receivedFlood" = "Recebidos (Flood)";
+"remoteNodes.status.receivedFlood" = "Recebidos (Difusão)";
 /* Location: SharedNodeStatusViews.swift - Duplicate packets label */
 "remoteNodes.status.duplicates" = "Duplicados";
 
@@ -507,7 +507,7 @@
 "remoteNodes.status.possibleMatchTitle" = "Possível correspondência";
 
 /* Location: RepeaterStatusView.swift - Explanation of what a possible match means */
-"remoteNodes.status.possibleMatchExplanation" = "Vários nodos partilham este prefixo. O nome apresentado pode não estar correto.";
+"remoteNodes.status.possibleMatchExplanation" = "Vários nós partilham este prefixo. O nome apresentado pode não estar correto.";
 
 // MARK: - Repeater Status ViewModel Messages
 
@@ -572,7 +572,7 @@
 "remoteNodes.status.sensor.switchValue" = "Interruptor";
 
 /* Location: RepeaterStatusView.swift - Neighbors section footer */
-"remoteNodes.status.neighborsFooter" = "Outros nodos descobertos por este repetidor e a qualidade do respetivo sinal.";
+"remoteNodes.status.neighborsFooter" = "Outros nós descobertos por este repetidor e a qualidade do respetivo sinal.";
 
 /* Location: RepeaterStatusView.swift - Discover neighbours button label */
 "remoteNodes.status.discoverNeighbors" = "Descobrir vizinhos";
@@ -682,7 +682,7 @@
 /* Location: RadioMetricCharts.swift - Direct packet series legend */
 "remoteNodes.history.direct" = "Direto";
 /* Location: RadioMetricCharts.swift - Flood packet series legend */
-"remoteNodes.history.flood" = "Flood";
+"remoteNodes.history.flood" = "Difusão";
 /* Location: RadioMetricCharts.swift - Duplicates chart title, under the Packets group header */
 "remoteNodes.history.duplicates" = "Duplicados";
 /* Location: RadioMetricCharts.swift - Section header grouping the packet-count charts */
@@ -728,7 +728,7 @@
 "remoteNodes.history.locationReportsHeader" = "Histórico de localização";
 
 /* Location: TelemetryHistoryOverviewView.swift - Purpose: Empty state when no snapshots exist */
-"remoteNodes.history.noSnapshotsMessage" = "Ligue a este nodo pelo menos uma vez para ver o histórico.";
+"remoteNodes.history.noSnapshotsMessage" = "Ligue a este nó pelo menos uma vez para ver o histórico.";
 
 /* Location: TelemetryHistoryOverviewView.swift - Purpose: Empty state when section data not captured */
 "remoteNodes.history.sectionNotCaptured" = "Estes dados são capturados ao visualizar a secção %@ durante uma sessão de telemetria em direto.";
@@ -751,7 +751,7 @@
 "remoteNodes.room.publicMessage" = "Mensagem pública";
 
 /* Location: RoomConversationView.swift - Read-only banner */
-"remoteNodes.room.viewOnlyBanner" = "Só de leitura - entre como membro para publicar";
+"remoteNodes.room.viewOnlyBanner" = "Só de leitura. Entre como membro para publicar";
 
 /* Location: RoomConversationView.swift - Hint text for read-only banner */
 "remoteNodes.room.viewOnlyHint" = "Toque para iniciar sessão";
@@ -850,7 +850,7 @@
 "remoteNodes.roomSettings.applyRoomSettings" = "Aplicar definições da sala";
 
 /* Location: RoomSettingsView.swift - Room behavior section footer */
-"remoteNodes.roomSettings.behaviorFooter" = "Intervalos de Advert e saltos flood.";
+"remoteNodes.roomSettings.behaviorFooter" = "Intervalos de Advert e saltos por difusão.";
 
 /* Location: RoomSettingsView.swift - Identity section footer */
 /* Location: RoomSettingsView.swift - Reboot confirmation title */
@@ -893,13 +893,13 @@
 "remoteNodes.nodeCli.helpClear" = "  clear\n    Limpar o terminal";
 
 /* Location: NodeCliViewModel.swift - Help entry for 'clear stats' command */
-"remoteNodes.nodeCli.helpClearStats" = "  clear stats\n    Repor as estatísticas do nodo";
+"remoteNodes.nodeCli.helpClearStats" = "  clear stats\n    Repor as estatísticas do nó";
 
 /* Location: NodeCliViewModel.swift - Help entry for 'reboot' command */
-"remoteNodes.nodeCli.helpReboot" = "  reboot\n    Reiniciar este nodo";
+"remoteNodes.nodeCli.helpReboot" = "  reboot\n    Reiniciar este nó";
 
 /* Location: NodeCliViewModel.swift - Passthrough note at end of help output */
-"remoteNodes.nodeCli.helpPassthrough" = "Qualquer outra entrada é enviada ao nodo.";
+"remoteNodes.nodeCli.helpPassthrough" = "Qualquer outra entrada é enviada ao nó.";
 
 // MARK: - Shared
 
@@ -907,7 +907,7 @@
 "remoteNodes.cancel" = "Cancelar";
 
 /* Location: Multiple files - Done button */
-"remoteNodes.done" = "OK";
+"remoteNodes.done" = "Concluído";
 
 /* Location: Multiple files - Name label */
 "remoteNodes.name" = "Nome";

--- a/MC1/Resources/Localization/pt.lproj/Settings.strings
+++ b/MC1/Resources/Localization/pt.lproj/Settings.strings
@@ -58,7 +58,7 @@
 // MARK: - Device Info View
 
 /* Navigation title for device info screen */
-"deviceInfo.title" = "Informações do dispositivo";
+"deviceInfo.title" = "Sobre o dispositivo";
 
 /* Section header for connection status */
 "deviceInfo.connection.header" = "Ligação";
@@ -97,10 +97,10 @@
 "deviceInfo.capabilities.header" = "Capacidades";
 
 /* Label for max nodes capability */
-"deviceInfo.maxNodes" = "Máximo de nodos";
+"deviceInfo.maxNodes" = "Capacidade máxima de nós";
 
 /* Label for max channels capability */
-"deviceInfo.maxChannels" = "Máximo de canais";
+"deviceInfo.maxChannels" = "Capacidade máxima de canais";
 
 /* Label for max TX power capability */
 "deviceInfo.maxTxPower" = "Potência de TX máxima";
@@ -205,7 +205,7 @@
 "locationPicker.clearLocation" = "Limpar localização";
 
 /* Button to drop a pin at the map center */
-"locationPicker.dropPin" = "Colocar alfinete no centro";
+"locationPicker.dropPin" = "Colocar ponto no centro";
 
 /* Label for latitude display */
 "locationPicker.latitude" = "Latitude:";
@@ -271,10 +271,10 @@
 "advancedRadio.bandwidth" = "Largura de banda (kHz)";
 
 /* Label for spreading factor picker */
-"advancedRadio.spreadingFactor" = "Fator de espalhamento";
+"advancedRadio.spreadingFactor" = "Fator de espalhamento (SF)";
 
 /* Label for coding rate picker */
-"advancedRadio.codingRate" = "Taxa de codificação";
+"advancedRadio.codingRate" = "Taxa de codificação (CR)";
 
 /* Label for TX power input */
 "advancedRadio.txPower" = "Potência de TX (dBm)";
@@ -283,7 +283,7 @@
 "advancedRadio.txPowerPlaceholder" = "dBm";
 
 /* Accessibility label for bandwidth picker options - %@ is formatted bandwidth value */
-"advancedRadio.accessibility.bandwidthLabel" = "%@ quilohertz";
+"advancedRadio.accessibility.bandwidthLabel" = "%@ kilohertz";
 
 /* Accessibility label for spreading factor picker options - %d is the factor value */
 "advancedRadio.accessibility.spreadingFactorLabel" = "Fator de espalhamento %d";
@@ -313,12 +313,12 @@
 "advancedRadio.repeatMode" = "Modo de repetidor";
 
 /* Footer explaining repeat mode in advanced radio */
-"advancedRadio.repeatMode.footer" = "Cria um repetidor local numa frequência dedicada. Útil para trilhos e zonas remotas. Frequências válidas: 433, 869.495, 918 MHz.";
+"advancedRadio.repeatMode.footer" = "Cria um repetidor local numa frequência dedicada. Útil para zonas remotas. Frequências válidas: 433, 869.495, 918 MHz.";
 
 // MARK: - Path Hash Mode Section
 
 /* Section header for path hash mode */
-"pathHashMode.header" = "Tamanho do hash do caminho";
+"pathHashMode.header" = "Tamanho do hash da rota";
 
 /* Label for path hash mode picker */
 "pathHashMode.label" = "Tamanho do hash";
@@ -333,15 +333,15 @@
 "pathHashMode.threeBytes" = "3 bytes";
 
 /* Footer explaining path hash mode tradeoff */
-"pathHashMode.footer" = "Hashes maiores reduzem colisões de routing, mas limitam o número máximo de saltos por caminho. Os repetidores com firmware anterior a 1.14.0 não repetem mensagens com hash maior que 1 byte.";
+"pathHashMode.footer" = "Hashes maiores reduzem colisões de encaminhamento, mas limitam o número máximo de saltos por rota. Os repetidores com firmware anterior a 1.14.0 não retransmitem mensagens com hash superior a 1 byte.";
 
 // MARK: - Default Flood Scope Section
 
 /* Section header for default flood scope picker */
-"defaultFloodScope.header" = "Âmbito de flood predefinido";
+"defaultFloodScope.header" = "Scope de difusão predefinido";
 
 /* Footer explaining default flood scope */
-"defaultFloodScope.footer" = "Quando definido, o dispositivo aplica este âmbito aos envios flood, a menos que um âmbito específico do canal o substitua. O âmbito é guardado no dispositivo e mantém-se após reinícios.";
+"defaultFloodScope.footer" = "Quando definido, o dispositivo aplica este scope aos envios por difusão, a menos que um scope específico do canal o substitua. O scope é guardado no dispositivo e mantém-se após reinícios.";
 
 /* Option to clear the persisted default flood scope */
 "defaultFloodScope.disabled" = "Nenhum";
@@ -445,7 +445,7 @@
 // MARK: - Nodes Settings Section
 
 /* Section header for nodes settings */
-"nodes.header" = "Nodos";
+"nodes.header" = "Nós";
 
 /* Label for auto-add mode picker */
 "nodes.autoAddMode" = "Modo de adição automática";
@@ -454,7 +454,7 @@
 "nodes.autoAddMode.manual" = "Manual";
 
 /* Auto-add mode: manual description */
-"nodes.autoAddMode.manualDescription" = "Reveja todos os nodos em Descobrir antes de adicionar";
+"nodes.autoAddMode.manualDescription" = "Reveja todos os nós em Descobrir antes de adicionar";
 
 /* Auto-add mode: selected types */
 "nodes.autoAddMode.selectedTypes" = "Tipos selecionados";
@@ -466,7 +466,7 @@
 "nodes.autoAddMode.all" = "Todos";
 
 /* Auto-add mode: all description */
-"nodes.autoAddMode.allDescription" = "Adicionar automaticamente todos os nodos descobertos";
+"nodes.autoAddMode.allDescription" = "Adicionar automaticamente todos os nós descobertos";
 
 /* Section header for auto-add types */
 /* Toggle label for auto-add contacts */
@@ -483,7 +483,7 @@
 "nodes.overwriteOldest" = "Substituir o mais antigo";
 
 /* Description for overwrite oldest toggle */
-"nodes.overwriteOldestDescription" = "Quando o armazenamento estiver cheio, substitui o nodo não favorito mais antigo";
+"nodes.overwriteOldestDescription" = "Quando o armazenamento estiver cheio, substituir o nó não favorito mais antigo";
 
 /* Picker label for max hop distance */
 "nodes.maxHops" = "Limite máximo de saltos na adição automática";
@@ -501,15 +501,15 @@
 "nodes.maxHops.hops" = "%d saltos";
 
 /* Footer text when hop limit is active */
-"nodes.maxHops.footerActive" = "Os nodos além da distância de saltos selecionada não serão adicionados automaticamente.";
+"nodes.maxHops.footerActive" = "Os nós acima do limite de saltos selecionado não serão adicionados automaticamente.";
 
 // MARK: - Auto-Remove Old Nodes Section
 
 /* Toggle label / section header for stale node cleanup */
-"nodes.staleCleanup.header" = "Remover automaticamente nodos antigos";
+"nodes.staleCleanup.header" = "Remover automaticamente nós antigos";
 
 /* Label for threshold picker */
-"nodes.staleCleanup.threshold" = "Remover nodos mais antigos que";
+"nodes.staleCleanup.threshold" = "Remover nós mais antigos do que";
 
 /* Picker placeholder when no threshold is selected */
 "nodes.staleCleanup.select" = "Selecionar";
@@ -518,16 +518,16 @@
 "nodes.staleCleanup.days" = "%d dias";
 
 /* Footer when auto-remove is enabled (%d = day count) */
-"nodes.staleCleanup.footerEnabled" = "Os nodos não favoritos não modificados em %d dias são removidos automaticamente na ligação.";
+"nodes.staleCleanup.footerEnabled" = "Os nós não favoritos sem alterações em %d dias são removidos automaticamente ao estabelecer ligação.";
 
 /* Footer describing the auto-remove feature (shown when toggle is off) */
-"nodes.staleCleanup.footerDisabled" = "Remove automaticamente nodos não favoritos que não foram modificados num período definido. Os favoritos nunca são removidos.";
+"nodes.staleCleanup.footerDisabled" = "Remove automaticamente nós não favoritos sem alterações durante o período definido. Os favoritos nunca são removidos.";
 
 /* Footer when toggle is on but no threshold selected yet */
-"nodes.staleCleanup.footerSelect" = "Escolha durante quanto tempo manter os nodos. Os favoritos nunca são removidos.";
+"nodes.staleCleanup.footerSelect" = "Escolha durante quanto tempo manter os nós. Os favoritos nunca são removidos.";
 
 /* Footer when enabled but device is disconnected */
-"nodes.staleCleanup.footerDisconnected" = "Irá verificar nodos antigos na próxima ligação. Os favoritos nunca são removidos.";
+"nodes.staleCleanup.footerDisconnected" = "Irá verificar nós antigos ao estabelecer ligação. Os favoritos nunca são removidos.";
 
 /* Last cleanup date row (%@ = relative date) */
 "nodes.staleCleanup.lastRun" = "Última verificação %@";
@@ -555,13 +555,13 @@
 // MARK: - Danger Zone Section
 
 /* Section header for danger zone */
-"dangerZone.header" = "Zona de perigo";
+"dangerZone.header" = "Zona perigosa";
 
 /* Button to forget/unpair the device */
 "dangerZone.forgetDevice" = "Esquecer dispositivo";
 
 /* Button to factory reset the device */
-"dangerZone.factoryReset" = "Repor o dispositivo de fábrica";
+"dangerZone.factoryReset" = "Repor definições de fábrica";
 
 /* Text shown while resetting */
 "dangerZone.resetting" = "A repor…";
@@ -582,7 +582,7 @@
 "dangerZone.dialog.forget.deleteAll" = "Esquecer dispositivo e eliminar dados";
 
 /* Alert title for factory reset confirmation */
-"dangerZone.alert.reset.title" = "Repor de fábrica";
+"dangerZone.alert.reset.title" = "Reposição de fábrica";
 
 /* Button to confirm reset */
 "dangerZone.alert.reset.confirm" = "Repor";
@@ -594,31 +594,31 @@
 "dangerZone.error.servicesUnavailable" = "Serviços indisponíveis";
 
 /* Button to remove non-favorite nodes */
-"dangerZone.removeUnfavorited" = "Remover nodos não favoritos";
+"dangerZone.removeUnfavorited" = "Remover nós não favoritos";
 
 /* Text shown while removing unfavorited nodes */
 "dangerZone.removing" = "A remover…";
 
 /* Label shown after successful removal */
-"dangerZone.removed" = "Nodos removidos";
+"dangerZone.removed" = "Nós removidos";
 
 /* Alert title for remove non-favorite confirmation */
-"dangerZone.alert.removeUnfavorited.title" = "Remover nodos não favoritos";
+"dangerZone.alert.removeUnfavorited.title" = "Remover nós não favoritos";
 
 /* Button to confirm removal */
-"dangerZone.alert.removeUnfavorited.confirm" = "Remover nodos";
+"dangerZone.alert.removeUnfavorited.confirm" = "Remover nós";
 
 /* Alert title for removal result */
 "dangerZone.alert.removeUnfavorited.resultTitle" = "Resultado da remoção";
 
 /* Alert message for remove unfavorited (%d = count) */
-"dangerZone.alert.removeUnfavorited.message" = "Isto irá eliminar permanentemente %d nodos não marcados como favoritos do dispositivo e da app, juntamente com as respetivas mensagens.";
+"dangerZone.alert.removeUnfavorited.message" = "Isto irá eliminar permanentemente do dispositivo e da app %d nós não marcados como favoritos, juntamente com as respetivas mensagens.";
 
 /* Partial success message (%d = removed, %d = total) */
-"dangerZone.alert.removeUnfavorited.partial" = "Removidos %d de %d nodos. A ligação foi interrompida — toque novamente no botão para tentar remover os nodos restantes.";
+"dangerZone.alert.removeUnfavorited.partial" = "Removidos %d de %d nós. A ligação foi interrompida. Toque novamente no botão para tentar remover os nós restantes.";
 
 /* Message when no non-favorite nodes to remove */
-"dangerZone.alert.removeUnfavorited.noneFound" = "Não há nodos não favoritos para remover.";
+"dangerZone.alert.removeUnfavorited.noneFound" = "Não há nós não favoritos para remover.";
 
 // MARK: - Diagnostics Section
 
@@ -660,7 +660,7 @@
 "linkPreviews.toggle" = "Mostrar conteúdo de ligações";
 
 /* Toggle label for showing link content in DMs */
-"linkPreviews.showInDMs" = "Mostrar em DMs";
+"linkPreviews.showInDMs" = "Mostrar em mensagens diretas";
 
 /* Toggle label for showing link content in channels */
 "linkPreviews.showInChannels" = "Mostrar em canais";
@@ -669,7 +669,7 @@
 "linkPreviews.footer" = "As pré-visualizações de ligações e as imagens são obtidas através da ligação à Internet do telemóvel, não da mesh. Isto pode revelar o endereço IP ao servidor que aloja o conteúdo e pode usar dados móveis.";
 
 /* Footer note shown when Reduce Motion is enabled */
-"linkPreviews.reduceMotionNote" = "Reduzir movimento está ativado, por isso os GIFs não serão reproduzidos automaticamente.";
+"linkPreviews.reduceMotionNote" = "A opção Reduzir movimento está ativada, por isso os GIFs não são reproduzidos automaticamente.";
 
 // MARK: - Inline Image Settings Section
 
@@ -685,15 +685,15 @@
 "mapPreviews.toggle" = "Mostrar miniaturas do mapa";
 
 /* Footer explaining map preview privacy implications */
-"mapPreviews.footer" = "Mostrar miniaturas do mapa obtém mosaicos do mapa para a coordenada a partir de um servidor de terceiros, o que pode revelar o endereço IP.";
+"mapPreviews.footer" = "Mostrar miniaturas do mapa vai buscar os mosaicos dessa coordenada a um servidor de terceiros, o que pode revelar o seu endereço IP.";
 
 // MARK: - Node Settings Section
 
 /* Section header for node settings */
-"node.header" = "Nodo";
+"node.header" = "Nó";
 
 /* Label for node name */
-"node.name" = "Nome do nodo";
+"node.name" = "Nome do nó";
 
 /* Default node name when unknown */
 /* Button text to copy */
@@ -710,10 +710,10 @@
 "node.shareLocationPublicly" = "Partilhar localização publicamente";
 
 /* Footer explaining node visibility */
-"node.footer" = "O nome do nodo fica visível para outros utilizadores da mesh quando é partilhado.";
+"node.footer" = "O nome do nó fica visível para outros utilizadores da mesh quando é partilhado.";
 
 /* Alert title for editing node name */
-"node.alert.editName.title" = "Editar nome do nodo";
+"node.alert.editName.title" = "Editar nome do nó";
 
 // MARK: - Location Settings Section
 
@@ -721,7 +721,7 @@
 "location.header" = "Localização";
 
 /* Footer for location settings section */
-"location.footer" = "Quando Partilhar localização publicamente está ativado, a localização será transmitida pela mesh ao enviar Adverts. Ativar Atualizar localização automaticamente atualiza a localização do dispositivo antes de enviar Adverts.";
+"location.footer" = "Com a opção «Partilhar localização publicamente» ativada, a localização é transmitida na mesh ao enviar Adverts. A opção «Atualizar localização automaticamente» atualiza a posição do dispositivo antes de cada Advert.";
 
 /* Toggle label for auto-update location */
 "location.autoUpdate" = "Atualizar localização automaticamente";
@@ -745,10 +745,10 @@
 "location.deviceGps.footer" = "Liga ou desliga o GPS integrado do rádio. Guardar uma localização manual no mapa desliga o GPS do dispositivo.";
 
 /* Detail text when location is being shared publicly */
-"location.sharingPublicly" = "Partilha pública";
+"location.sharingPublicly" = "Partilhada publicamente";
 
 /* Detail text when location is not being shared */
-"location.notSharing" = "Sem partilha";
+"location.notSharing" = "Não partilhada";
 
 // MARK: - Notification Settings Section
 
@@ -768,7 +768,7 @@
 "notifications.newContactDiscovered" = "Novo contacto descoberto";
 
 /* Toggle label for companion discovery notifications */
-"notifications.discoveryContact" = "Companion";
+"notifications.discoveryContact" = "Contacto";
 
 /* Toggle label for repeater discovery notifications */
 "notifications.discoveryRepeater" = "Repetidor";
@@ -808,7 +808,7 @@
 "radio.repeatMode" = "Modo de repetidor";
 
 /* Footer explaining repeat mode */
-"radio.repeatMode.footer" = "Cria um repetidor local numa frequência dedicada. Útil para trilhos e zonas remotas.";
+"radio.repeatMode.footer" = "Cria um repetidor local numa frequência dedicada. Útil para zonas remotas.";
 
 /* Accessibility hint for repeat mode toggle */
 "radio.repeatMode.accessibilityHint" = "Ativar isto irá desligar da rede mesh principal";
@@ -837,7 +837,7 @@
 "telemetry.allowRequests" = "Permitir pedidos de telemetria";
 
 /* Description for telemetry requests toggle */
-"telemetry.allowRequestsDescription" = "Necessário para que outros utilizadores possam traçar manualmente um caminho até si. Partilha o nível da bateria.";
+"telemetry.allowRequestsDescription" = "Necessário para que outros utilizadores possam traçar manualmente uma rota até si. Partilha o nível da bateria.";
 
 /* Toggle label for including location in telemetry */
 "telemetry.includeLocation" = "Incluir localização";
@@ -861,7 +861,7 @@
 "telemetry.manageTrusted" = "Gerir contactos de confiança";
 
 /* Footer explaining telemetry */
-"telemetry.footer" = "Quando ativado, outros nodos podem pedir os dados de telemetria do dispositivo.";
+"telemetry.footer" = "Quando ativado, outros nós podem pedir os dados de telemetria do dispositivo.";
 
 // MARK: - WiFi Section
 
@@ -896,7 +896,7 @@
 "wifiEdit.footer" = "Alterar estes valores irá desligar e voltar a ligar ao novo endereço.";
 
 /* Text shown while reconnecting */
-"wifiEdit.reconnecting" = "A religar…";
+"wifiEdit.reconnecting" = "A restabelecer ligação…";
 
 /* Button to save changes */
 "wifiEdit.saveChanges" = "Guardar alterações";
@@ -944,27 +944,27 @@
 
 /* Toggle label for showing the raw uncorrected wire send time on incoming messages */
 /* Toggle label for showing routing path on incoming messages */
-"messages.showIncomingPath" = "Caminho de entrada";
+"messages.showIncomingPath" = "Rota";
 
 /* Toggle label for showing hop count on incoming messages */
-"messages.showIncomingHopCount" = "Número de saltos de entrada";
+"messages.showIncomingHopCount" = "Número de saltos";
 
 /* Toggle label for showing the radio region an incoming message was flooded under */
-"messages.showIncomingRegion" = "Região de entrada";
+"messages.showIncomingRegion" = "Região";
 
 /* Footer explaining what the message display options show */
-"messages.footer" = "Mostra informações de routing e de tempo nos balões das mensagens recebidas.";
+"messages.footer" = "Mostra informações de encaminhamento e de tempo nos balões das mensagens recebidas.";
 
 // MARK: - Direct Messages Settings Section
 
 /* Section header for direct message settings */
-"directMessages.header" = "DMs";
+"directMessages.header" = "Mensagens diretas";
 
 /* Picker label for number of acknowledgments */
 "directMessages.acknowledgments" = "Confirmações";
 
 /* Footer explaining the acknowledgments setting */
-"directMessages.footer" = "Número de confirmações enviadas por DM. Use 2 para melhor confirmação de entrega em ligações pouco fiáveis.";
+"directMessages.footer" = "Número de confirmações enviadas por mensagem direta. Use 2 para melhor confirmação de entrega em ligações pouco fiáveis.";
 
 // MARK: - BLE Status Indicator
 
@@ -972,7 +972,7 @@
 "bleStatus.sendZeroHopAdvert" = "Enviar Advert zero-hop";
 
 /* Menu item to send a flood advertisement */
-"bleStatus.sendFloodAdvert" = "Enviar Advert flood";
+"bleStatus.sendFloodAdvert" = "Enviar Advert por difusão";
 
 /* Menu item to change the connected device */
 "bleStatus.changeDevice" = "Mudar de dispositivo";
@@ -981,7 +981,7 @@
 "bleStatus.disconnect" = "Desligar";
 
 /* Status shown when device is disconnected */
-"bleStatus.status.disconnected" = "Desligado";
+"bleStatus.status.disconnected" = "Sem ligação";
 
 /* Status shown when device is connecting */
 "bleStatus.status.connecting" = "A ligar…";
@@ -1019,7 +1019,7 @@
 "configExport.sectionTitle" = "Configuração do dispositivo";
 
 /* Section footer explaining config export/import */
-"configExport.sectionFooter" = "Exporte ou importe definições do dispositivo, canais e contactos como um ficheiro JSON.";
+"configExport.sectionFooter" = "Exporte ou importe definições do dispositivo, canais e contactos através de um ficheiro JSON.";
 
 /* Export navigation row label */
 "configExport.export" = "Exportar config";
@@ -1038,7 +1038,7 @@
 "configExport.selectAll" = "Selecionar tudo";
 
 /* Toggle labels for export sections */
-"configExport.nodeIdentity" = "Identidade do nodo (nome e chaves)";
+"configExport.nodeIdentity" = "Identidade do nó (nome e chaves)";
 "configExport.nodeIdentity.description" = "Nome do dispositivo, chave pública e chave privada";
 "configExport.radioSettings" = "Definições do rádio";
 "configExport.radioSettings.description" = "Frequência, largura de banda, fator de espalhamento, taxa de codificação, potência de TX";
@@ -1105,7 +1105,7 @@
 "configImport.importSuccess" = "Configuração importada com êxito";
 
 /* Private key warning */
-"configImport.privateKeyWarning" = "Isto irá substituir a identidade criptográfica do nodo";
+"configImport.privateKeyWarning" = "Isto irá substituir a identidade criptográfica do nó";
 
 "configImport.current" = "Atual: %@";
 "configImport.new" = "Novo: %@";
@@ -1135,7 +1135,7 @@
 "configImport.stepPrivateKey" = "A importar a chave privada";
 
 /* Import progress: setting the node name */
-"configImport.stepNodeName" = "A definir o nome do nodo";
+"configImport.stepNodeName" = "A definir o nome do nó";
 
 /* Import progress: applying radio parameters */
 "configImport.stepRadioParameters" = "A definir os parâmetros do rádio";
@@ -1153,13 +1153,13 @@
 "configImport.field.frequency" = "Frequência";
 
 /* Validation field label: radio bandwidth */
-"configImport.field.bandwidth" = "Largura de banda";
+"configImport.field.bandwidth" = "Largura de banda (BW)";
 
 /* Validation field label: spreading factor */
-"configImport.field.spreadingFactor" = "Fator de espalhamento";
+"configImport.field.spreadingFactor" = "Fator de espalhamento (SF)";
 
 /* Validation field label: coding rate */
-"configImport.field.codingRate" = "Taxa de codificação";
+"configImport.field.codingRate" = "Taxa de codificação (CR)";
 
 /* Validation field label: TX power */
 "configImport.field.txPower" = "Potência de TX";
@@ -1180,7 +1180,7 @@
 "configImport.error.contactCoordinateInvalid" = "O contacto \"%@\" %@ tem uma coordenada inválida ou fora do intervalo";
 
 /* Validation error: contact has an invalid routing path (param: contact name) */
-"configImport.error.invalidOutPath" = "O contacto \"%@\" tem um caminho de routing inválido";
+"configImport.error.invalidOutPath" = "O contacto \"%@\" tem uma rota inválida";
 
 /* Validation error: not enough free contact slots (params: needed count, available count) */
 "configImport.error.contactCapacityExceeded" = "A importação precisa de %d slot(s) de contacto livre(s), mas restam apenas %d no dispositivo";
@@ -1192,7 +1192,7 @@
 "configImport.error.invalidContactPublicKey" = "O contacto \"%@\" tem uma chave pública inválida";
 
 /* Validation error: unsupported path hash mode (params: contact name, mode value) */
-"configImport.error.invalidPathHashMode" = "O contacto \"%1$@\" tem um modo de hash do caminho não suportado %2$lld (esperado 0, 1 ou 2)";
+"configImport.error.invalidPathHashMode" = "O contacto \"%1$@\" tem um modo de hash da rota inválido %2$lld (esperado 0, 1 ou 2)";
 
 /* Validation error: private key wrong length (params: hex char count, expected hex char count) */
 "configImport.error.invalidPrivateKey" = "Chave privada inválida (%1$lld caracteres hex, esperados %2$lld)";
@@ -1215,7 +1215,7 @@
 "blocking.channelSenders.title" = "Remetentes de canal bloqueados";
 
 /* Location: BlockedChannelSendersView.swift - Purpose: Empty state title */
-"blocking.channelSenders.empty.title" = "Nenhum utilizador bloqueado";
+"blocking.channelSenders.empty.title" = "Nenhum remetente bloqueado";
 
 /* Location: BlockedChannelSendersView.swift - Purpose: Empty state description */
 "blocking.channelSenders.empty.description" = "Os nomes de remetentes de canal que bloquear aparecem aqui.";
@@ -1251,7 +1251,7 @@
 "liveActivity.tip.title" = "Estado do rádio num relance";
 
 /* Message for the Live Activity tip */
-"liveActivity.tip.message" = "A ligação, a bateria e as mensagens ficam visíveis — mesmo sem abrir a app.";
+"liveActivity.tip.message" = "A ligação, a bateria e as mensagens ficam visíveis, mesmo sem abrir a app.";
 
 // MARK: - Regenerate Identity
 
@@ -1427,7 +1427,7 @@
 "offlineMaps.downloadHint" = "Introduza um nome e selecione uma área para transferir.";
 
 /* Download exceeds available storage */
-"offlineMaps.exceedsStorage" = "Não há armazenamento suficiente neste dispositivo. Aproxime o zoom para selecionar uma área menor.";
+"offlineMaps.exceedsStorage" = "Não há armazenamento suficiente neste dispositivo. Aumente o zoom para selecionar uma área menor.";
 
 /* Layer type labels */
 "offlineMaps.layer.base" = "Mapa base";
@@ -1452,7 +1452,7 @@
 "settings.backup.file_backup.header" = "Backup em ficheiro";
 
 /* Section footer for file backup */
-"settings.backup.file_backup.footer" = "Exporte ou restaure mensagens, contactos, canais, caminhos guardados e definições. A configuração do rádio é lida do dispositivo em cada ligação.";
+"settings.backup.file_backup.footer" = "Exporte ou restaure mensagens, contactos, canais, rotas guardadas e definições. A configuração do rádio é lida do dispositivo em cada ligação.";
 
 /* Export row title */
 "settings.backup.export.title" = "Exportar dados da app";
@@ -1473,7 +1473,7 @@
 "settings.backup.export.alert.title" = "Aviso de segurança";
 
 /* Export confirmation alert message */
-"settings.backup.export.alert.message" = "Este backup inclui as chaves de encriptação dos canais, o histórico de mensagens, a lista de contactos e o endereço de rede local e a porta do nodo Wi-Fi. Guarde o ficheiro exportado de forma segura.";
+"settings.backup.export.alert.message" = "Este backup inclui as chaves de encriptação dos canais, o histórico de mensagens, a lista de contactos, o endereço de rede local e a porta do nó Wi-Fi. Guarde o ficheiro exportado de forma segura.";
 
 /* Export confirmation alert export button */
 "settings.backup.export.alert.export" = "Exportar";
@@ -1518,10 +1518,10 @@
 "settings.backup.import.preview.reactions" = "Reações";
 
 /* Import preview manifest label: saved paths */
-"settings.backup.import.preview.saved_paths" = "Caminhos guardados";
+"settings.backup.import.preview.saved_paths" = "Rotas guardadas";
 
 /* Import preview manifest label: remote node sessions */
-"settings.backup.import.preview.remote_node_sessions" = "Sessões de nodos remotos";
+"settings.backup.import.preview.remote_node_sessions" = "Sessões de nós remotos";
 
 /* Import preview info text */
 "settings.backup.import.preview.info" = "Apenas os dados novos são adicionados; os registos existentes não são substituídos. Os contactos eliminados depois de este backup ter sido criado voltam a aparecer, e quaisquer estados de bloqueio, silenciado ou favorito do backup são reaplicados.";
@@ -1572,13 +1572,13 @@
 "settings.backup.import.success.dropped_footer" = "Estes canais não tinham slot livre neste rádio, por isso eles e as respetivas mensagens não foram importados. Liberte um slot de canal e importe novamente para os restaurar.";
 
 /* Import success footer when only discovered nodes exceeded the per-radio discover-list cap */
-"settings.backup.import.success.dropped_footer_discovered_nodes" = "Estes nodos descobertos não puderam ser restaurados porque a lista de descoberta deste rádio está cheia (%d nodos). Os nodos locais existentes foram mantidos; a mesh voltará a emitir Adverts dos que faltam.";
+"settings.backup.import.success.dropped_footer_discovered_nodes" = "Estes nós descobertos não puderam ser restaurados porque a lista de descoberta deste rádio está cheia (%d nós). Os nós locais existentes foram mantidos; a mesh voltará a emitir Adverts dos nós que faltam.";
 
 /* Import success footer when both channel slots and the discover-list cap caused drops */
-"settings.backup.import.success.dropped_footer_mixed" = "Alguns itens não puderam ser restaurados: canais sem slot livre no rádio e nodos descobertos que excederam a capacidade da lista de descoberta deste rádio (%d nodos). Liberte um slot de canal e importe novamente os canais; a mesh voltará a emitir Adverts dos nodos descobertos em falta.";
+"settings.backup.import.success.dropped_footer_mixed" = "Alguns itens não puderam ser restaurados: canais sem slot livre no rádio e nós descobertos que excederam a capacidade da lista de descoberta deste rádio (%d nós). Liberte um slot de canal e importe novamente os canais; a mesh voltará a emitir Adverts dos nós descobertos em falta.";
 
 /* Import success done button */
-"settings.backup.import.success.done" = "OK";
+"settings.backup.import.success.done" = "Concluído";
 
 /* Import failure title */
 "settings.backup.import.error.title" = "Falha na importação";
@@ -1597,13 +1597,13 @@
 "settings.backup.import.preview.blocked_senders" = "Remetentes bloqueados";
 
 /* Import preview manifest label: node status snapshots */
-"settings.backup.import.preview.node_status_snapshots" = "Instantâneos de nodos";
+"settings.backup.import.preview.node_status_snapshots" = "Instantâneos de nós";
 
 /* Import preview manifest label: discovered nodes */
-"settings.backup.import.preview.discovered_nodes" = "Nodos descobertos";
+"settings.backup.import.preview.discovered_nodes" = "Nós descobertos";
 
 /* Import preview manifest label: message repeats */
-"settings.backup.import.preview.message_repeats" = "Repetições de mensagens";
+"settings.backup.import.preview.message_repeats" = "Retransmissões de mensagens";
 
 /* Import header title when the backup had nothing new to add (every record was skipped) */
 "settings.backup.import.nothing_to_import.title" = "Já está tudo aqui";
@@ -1644,7 +1644,7 @@
 "settings.backup.export.success.included_section" = "Incluído no backup";
 
 /* Primary button on the export success sheet */
-"settings.backup.export.success.done" = "OK";
+"settings.backup.export.success.done" = "Concluído";
 
 /* VoiceOver announcement when the export success sheet appears; %@ is the filename */
 "settings.backup.export.success.announcement" = "Backup guardado como %@";
@@ -1705,10 +1705,10 @@
 "Support.Accessibility.ThemeCard.LockedLabel" = "Tema %@, bloqueado";
 "Support.Accessibility.ThemeCard.OwnedLabel" = "Tema %@, adquirido";
 "Support.Accessibility.BundleCard.LockedLabel" = "Pacote Todos os temas, bloqueado, %@";
-"Support.Accessibility.BundleCard.LockedHint" = "Compra o pacote Todos os temas";
+"Support.Accessibility.BundleCard.LockedHint" = "Compre o pacote Todos os temas";
 "Support.Accessibility.BundleCard.LoadingLabel" = "Pacote Todos os temas, a carregar o preço";
 "Support.Accessibility.ContributionRow.Label" = "%1$@, %2$@";
-"Support.Accessibility.ContributionRow.Hint" = "Envia um donativo de agradecimento";
+"Support.Accessibility.ContributionRow.Hint" = "Envie um donativo de agradecimento";
 "Support.Accessibility.TipConfirmAnnouncement" = "Obrigado pelo donativo.";
 
 /* MARK: Appearance (selection) screen */

--- a/MC1/Resources/Localization/pt.lproj/Settings.stringsdict
+++ b/MC1/Resources/Localization/pt.lproj/Settings.stringsdict
@@ -21,9 +21,9 @@
             <key>NSStringFormatValueTypeKey</key>
             <string>d</string>
             <key>one</key>
-            <string>Isto irá eliminar permanentemente %d nodo não marcado como favorito do dispositivo e da app, juntamente com as respetivas mensagens.</string>
+            <string>Isto irá eliminar permanentemente do dispositivo e da app %d nó não marcado como favorito, juntamente com as respetivas mensagens.</string>
             <key>other</key>
-            <string>Isto irá eliminar permanentemente %d nodos não marcados como favoritos do dispositivo e da app, juntamente com as respetivas mensagens.</string>
+            <string>Isto irá eliminar permanentemente do dispositivo e da app %d nós não marcados como favoritos, juntamente com as respetivas mensagens.</string>
         </dict>
     </dict>
     <key>dangerZone.alert.removeUnfavorited.partial</key>
@@ -37,9 +37,9 @@
             <key>NSStringFormatValueTypeKey</key>
             <string>d</string>
             <key>one</key>
-            <string>Removido %1$d de %2$d nodo. A ligação foi interrompida — toque novamente no botão para tentar de novo.</string>
+            <string>Removido %1$d de %2$d nó. A ligação foi interrompida. Toque novamente no botão para tentar de novo.</string>
             <key>other</key>
-            <string>Removidos %1$d de %2$d nodos. A ligação foi interrompida — toque novamente no botão para tentar remover os nodos restantes.</string>
+            <string>Removidos %1$d de %2$d nós. A ligação foi interrompida. Toque novamente no botão para tentar remover os nós restantes.</string>
         </dict>
     </dict>
     <key>settings.backup.import.success.subtitle_added</key>

--- a/MC1/Resources/Localization/pt.lproj/Tools.strings
+++ b/MC1/Resources/Localization/pt.lproj/Tools.strings
@@ -12,19 +12,19 @@
 "tools.title" = "Ferramentas";
 
 /* Location: ToolsView.swift - Tool selection label */
-"tools.tracePath" = "Traçar caminho";
+"tools.tracePath" = "Traçar rota";
 
 /* Location: ToolsView.swift - Tool selection label */
 "tools.lineOfSight" = "Linha de vista";
 
 /* Location: ToolsView.swift - Tool selection label */
-"tools.rxLog" = "Registo RX";
+"tools.rxLog" = "Log RX";
 
 /* Location: ToolsView.swift - Tool selection label */
 "tools.noiseFloor" = "Ruído de fundo";
 
 /* Location: ToolsView.swift - Tool selection label */
-"tools.nodeDiscovery" = "Descobrir nodos";
+"tools.nodeDiscovery" = "Descobrir nós";
 
 /* Location: ToolsView.swift - Empty state when no tool selected */
 "tools.selectTool" = "Selecione uma ferramenta";
@@ -38,7 +38,7 @@
 "tools.rxLog.listeningDescription" = "Os pacotes RF aparecem aqui à medida que chegam.";
 
 /* Location: RxLogView.swift - Disconnected state title */
-"tools.rxLog.notConnected" = "Não ligado";
+"tools.rxLog.notConnected" = "Sem ligação";
 
 /* Location: RxLogView.swift - Disconnected state description */
 "tools.rxLog.notConnectedDescription" = "Ligue o rádio mesh para ver os pacotes RF.";
@@ -86,7 +86,7 @@
 "tools.rxLog.hopPlural" = "saltos";
 
 /* Location: RxLogView.swift - Signal strength accessibility label, %@ is quality */
-"tools.rxLog.signalStrength" = "Intensidade do sinal: %@";
+"tools.rxLog.signalStrength" = "Sinal: %@";
 
 /* Location: RxLogView.swift - Duplicate count accessibility label, %lld is count */
 "tools.rxLog.receivedTimes" = "Recebido %lld vezes";
@@ -110,7 +110,7 @@
 "tools.rxLog.sizeLabel" = "Tamanho:";
 
 /* Location: RxLogView.swift - Path label */
-"tools.rxLog.pathLabel" = "Caminho:";
+"tools.rxLog.pathLabel" = "Rota:";
 
 /* Location: RxLogView.swift - Hash label */
 "tools.rxLog.hashLabel" = "Hash:";
@@ -145,7 +145,7 @@
 "tools.rxLog.filter.all" = "Todos";
 
 /* Location: RxLogViewModel.swift - Route filter: flood only */
-"tools.rxLog.filter.floodOnly" = "Só Flood";
+"tools.rxLog.filter.floodOnly" = "Só difusão";
 
 /* Location: RxLogViewModel.swift - Route filter: direct only */
 "tools.rxLog.filter.directOnly" = "Só direto";
@@ -157,7 +157,7 @@
 "tools.rxLog.filter.failed" = "Falhou";
 
 /* Location: DecryptStatus+Display.swift - Decrypt status: not a decryptable packet */
-"tools.rxLog.decryptStatus.notApplicable" = "N/A";
+"tools.rxLog.decryptStatus.notApplicable" = "N/D";
 
 /* Location: DecryptStatus+Display.swift - Decrypt status: no stored channel key matches */
 "tools.rxLog.decryptStatus.noKey" = "Sem chave";
@@ -175,7 +175,7 @@
 "tools.rxLog.decryptStatus.hasKey" = "Com chave";
 
 /* Location: DecryptStatus+Display.swift - Decrypt status: missing direct message key */
-"tools.rxLog.decryptStatus.noDmKey" = "Sem chave DM";
+"tools.rxLog.decryptStatus.noDmKey" = "Sem chave de contacto";
 
 /* Location: RxLogRowView - Label for local device in path display */
 "tools.rxLog.pathYou" = "Eu";
@@ -274,7 +274,7 @@
 "tools.nodeDiscovery.noResults" = "Sem resultados para %@";
 
 /* Location: NodeDiscoveryView.swift - No results empty state description */
-"tools.nodeDiscovery.noResultsDescription" = "%@ não responderam ao ping de descoberta. Tente novamente ou aproxime-se da mesh.";
+"tools.nodeDiscovery.noResultsDescription" = "Nenhum dos %@ respondeu ao ping de descoberta. Tente novamente ou aproxime-se de um nó da mesh.";
 
 /* Location: NodeDiscoveryView.swift - Scan button label (idle) */
 "tools.nodeDiscovery.scanButton" = "Procurar %@";
@@ -295,10 +295,10 @@
 "tools.nodeDiscovery.sortName" = "Nome";
 
 /* Location: NodeDiscoveryView.swift - Sort menu accessibility label */
-"tools.nodeDiscovery.sortMenu" = "Ordenar nodos";
+"tools.nodeDiscovery.sortMenu" = "Ordenar nós";
 
 /* Location: NodeDiscoveryView.swift - Sort menu accessibility hint */
-"tools.nodeDiscovery.sortMenuHint" = "Altera a ordem dos nodos descobertos";
+"tools.nodeDiscovery.sortMenuHint" = "Altera a ordem dos nós descobertos";
 
 /* Location: NodeDiscoveryRowView.swift - Unknown node name fallback */
 "tools.nodeDiscovery.unknownNode" = "Desconhecido";
@@ -356,7 +356,7 @@
 "tools.lineOfSight.loadingElevation" = "A carregar altitude...";
 
 /* Location: LineOfSightView.swift - Long press points hint */
-"tools.lineOfSight.longPressPointsHint" = "Toque e mantenha premido no mapa para adicionar um local";
+"tools.lineOfSight.longPressPointsHint" = "Toque sem soltar no mapa para adicionar um local";
 
 /* Location: LineOfSightView.swift - Elevation unavailable warning */
 "tools.lineOfSight.elevationUnavailable" = "Dados de altitude indisponíveis. A utilizar o nível do mar (0 m) como aproximação.";
@@ -377,7 +377,7 @@
 "tools.lineOfSight.relocate" = "Reposicionar";
 
 /* Location: LineOfSightView.swift - Done button */
-"tools.lineOfSight.done" = "OK";
+"tools.lineOfSight.done" = "Concluído";
 
 /* Location: LineOfSightView.swift - Edit button */
 "tools.lineOfSight.edit" = "Editar";
@@ -428,10 +428,10 @@
 "tools.lineOfSight.refraction.standard" = "Padrão (k=1,33)";
 
 /* Location: LineOfSightView.swift - Refraction: ducting */
-"tools.lineOfSight.refraction.ducting" = "Ducting (k=4)";
+"tools.lineOfSight.refraction.ducting" = "Conduta (k=4)";
 
 /* Location: LineOfSightView.swift - Analyzing progress */
-"tools.lineOfSight.analyzing" = "A analisar o caminho...";
+"tools.lineOfSight.analyzing" = "A analisar o percurso...";
 
 /* Location: LineOfSightView.swift - Analysis failed title */
 "tools.lineOfSight.analysisFailed" = "A análise falhou";
@@ -443,7 +443,7 @@
 "tools.lineOfSight.repeaterLocation" = "Localização do repetidor";
 
 /* Location: LineOfSightViewModel.swift - Dropped pin display name */
-"tools.lineOfSight.droppedPin" = "Alfinete largado";
+"tools.lineOfSight.droppedPin" = "Ponto no mapa";
 
 /* Location: LOSRepeaterPinView.swift - Accessibility hint for repeater pins */
 /* Location: LOSPointPinView.swift - Accessibility hint for point pins */
@@ -483,7 +483,7 @@
 "tools.lineOfSight.loss" = "perda";
 
 /* Location: ResultsCardView.swift - Path loss breakdown section */
-"tools.lineOfSight.pathLossBreakdown" = "Detalhe da perda de caminho";
+"tools.lineOfSight.pathLossBreakdown" = "Detalhe da perda de percurso";
 
 /* Location: ResultsCardView.swift - Free space loss label */
 "tools.lineOfSight.freeSpaceLoss" = "Perda em espaço livre";
@@ -519,7 +519,7 @@
 "tools.lineOfSight.status.clear" = "Livre";
 
 /* Location: ClearanceStatusView.swift, ResultsCardView.swift - Clearance status: marginal */
-"tools.lineOfSight.status.marginal" = "Marginal";
+"tools.lineOfSight.status.marginal" = "No limite";
 
 /* Location: ClearanceStatusView.swift, ResultsCardView.swift - Clearance status: partial obstruction */
 "tools.lineOfSight.status.partialObstruction" = "Obstrução parcial";
@@ -528,7 +528,7 @@
 "tools.lineOfSight.status.blocked" = "Bloqueado";
 
 /* Location: ResultsCardView.swift - Subtitle shown when path is blocked */
-"tools.lineOfSight.status.blockedSubtitle" = "O caminho direto intersecta o terreno";
+"tools.lineOfSight.status.blockedSubtitle" = "O percurso direto intersecta o terreno";
 
 // MARK: - CLI Tool View
 
@@ -536,7 +536,7 @@
 "tools.cli" = "CLI";
 
 /* Location: CLIToolView.swift - Disconnected state title */
-"tools.cli.notConnected" = "Não ligado";
+"tools.cli.notConnected" = "Sem ligação";
 
 /* Location: CLIToolView.swift - Disconnected state description */
 "tools.cli.notConnectedDescription" = "Ligue o rádio mesh para utilizar a CLI.";
@@ -572,7 +572,7 @@
 "tools.cli.loginFailedAuth" = "Falha na autenticação";
 
 /* Location: CLIToolView.swift - Node not found error */
-"tools.cli.nodeNotFound" = "Nodo não encontrado:";
+"tools.cli.nodeNotFound" = "Nó não encontrado:";
 
 /* Location: CLIToolView.swift - Password required error */
 "tools.cli.passwordRequired" = "Palavra-passe necessária";
@@ -681,13 +681,13 @@
 "tools.cli.helpRepeaterList4" = "  setperm, tempradio, neighbor.remove";
 
 /* Location: CLIToolViewModel+Sessions.swift - Nodes header with count */
-"tools.cli.nodesHeader" = "Nodos (%lld):";
+"tools.cli.nodesHeader" = "Nós (%lld):";
 
 /* Location: CLIToolViewModel+Sessions.swift - Channels header with count */
 "tools.cli.channelsHeader" = "Canais (%lld):";
 
 /* Location: CLIToolViewModel+Sessions.swift - No nodes found */
-"tools.cli.noNodes" = "Nenhum nodo encontrado";
+"tools.cli.noNodes" = "Nenhum nó encontrado";
 
 /* Location: CLIToolViewModel+Sessions.swift - No channels found */
 "tools.cli.noChannels" = "Nenhum canal encontrado";
@@ -705,7 +705,7 @@
 "tools.cli.welcomeHint" = "Introduza 'help' para ver os comandos disponíveis.";
 
 /* Location: CLIToolView.swift - Jump to bottom button */
-"tools.cli.jumpToBottom" = "Ir para o fundo";
+"tools.cli.jumpToBottom" = "Ir para o fim";
 
 /* Location: CLIToolView.swift - Accessibility label for command input */
 "tools.cli.commandInput" = "Introdução de comando";
@@ -763,13 +763,13 @@
 // MARK: - Saved Paths
 
 /* Location: SavedPathsViewModel.swift - Error loading saved paths */
-"tools.savedPaths.loadFailed" = "Não foi possível carregar os caminhos guardados.";
+"tools.savedPaths.loadFailed" = "Não foi possível carregar as rotas guardadas.";
 
 /* Location: SavedPathsViewModel.swift - Error renaming a saved path */
-"tools.savedPaths.renameFailed" = "Não foi possível mudar o nome do caminho.";
+"tools.savedPaths.renameFailed" = "Não foi possível mudar o nome da rota.";
 
 /* Location: SavedPathsViewModel.swift - Error deleting a saved path */
-"tools.savedPaths.deleteFailed" = "Não foi possível eliminar o caminho.";
+"tools.savedPaths.deleteFailed" = "Não foi possível eliminar a rota.";
 
 // MARK: - App Intents
 
@@ -842,22 +842,22 @@
 "intent.advert.shortTitle" = "Enviar Advert";
 
 /* Location: SendAdvertIntent.swift - App Intents: description of the send advert intent */
-"intent.advert.description" = "Emite um Advert deste rádio para que os nodos da mesh próximos o possam descobrir.";
+"intent.advert.description" = "Emite um Advert deste rádio para que os nós da mesh próximos o possam descobrir.";
 
 /* Location: SendAdvertIntent.swift - App Intents: title of the advert reach parameter (zero-hop or flood) */
-"intent.advert.param.reach" = "Âmbito";
+"intent.advert.param.reach" = "Alcance";
 
 /* Location: AdvertReach.swift - App Intents: type name for the advert reach enum */
-"intent.advert.reach.type" = "Âmbito do Advert";
+"intent.advert.reach.type" = "Alcance do Advert";
 
 /* Location: AdvertReach.swift - App Intents: zero-hop reach case (direct neighbors only) */
 "intent.advert.reach.zeroHop" = "Zero-hop";
 
 /* Location: AdvertReach.swift - App Intents: flood reach case (entire mesh) */
-"intent.advert.reach.flood" = "Flood";
+"intent.advert.reach.flood" = "Difusão";
 
 /* Location: SendAdvertIntent.swift - Spoken after a zero-hop advert is sent */
-"intent.advert.dialog.sentZeroHop" = "Advert enviado para os nodos próximos.";
+"intent.advert.dialog.sentZeroHop" = "Advert enviado para os nós próximos.";
 
 /* Location: SendAdvertIntent.swift - Spoken after a flood advert is sent */
 "intent.advert.dialog.sentFlood" = "Advert enviado por toda a mesh.";

--- a/MC1/Resources/Localization/pt.lproj/WhatsNew.strings
+++ b/MC1/Resources/Localization/pt.lproj/WhatsNew.strings
@@ -13,12 +13,12 @@
 "whatsNew.continueButton" = "Continuar";
 
 /* Link on the What's New sheet to the full GitHub release notes */
-"whatsNew.fullReleaseNotes" = "Notas de versão completas";
+"whatsNew.fullReleaseNotes" = "Ver as notas de versão completas";
 
 /* What's New v1.3 - Improved chats feature, title */
-"whatsNew.fasterChats.title" = "Chats melhorados";
+"whatsNew.fasterChats.title" = "Conversas melhoradas";
 /* What's New v1.3 - Improved chats feature, description */
-"whatsNew.fasterChats.description" = "Ao abrir um chat, o ecrã salta para as mensagens novas em vez do fim. A hora aparece em cada balão, e o histórico e as pré-visualizações de ligações carregam mais depressa.";
+"whatsNew.fasterChats.description" = "Ao abrir uma conversa, o ecrã salta para as mensagens novas em vez de ir para o fim. A hora aparece em cada balão, e o histórico e as pré-visualizações de links carregam mais depressa.";
 
 /* What's New v1.3 - Contact photos feature, title */
 "whatsNew.contactPhotos.title" = "Fotos de contactos";
@@ -28,4 +28,4 @@
 /* What's New v1.3 - Map filters feature, title */
 "whatsNew.mapFilters.title" = "Filtros do mapa";
 /* What's New v1.3 - Map filters feature, description */
-"whatsNew.mapFilters.description" = "Filtre os alfinetes por favoritos, nodos descobertos e tipo de nodo.";
+"whatsNew.mapFilters.description" = "Filtre os pontos por favoritos, nós descobertos e tipo de nó.";


### PR DESCRIPTION
## Description

Verified and updated the translation files for Portuguese (Portugal) (pt-PT),
following up on #408.

## Tested on
- [x] iOS [26.6]
- [ ] iPadOS [version]
- [ ] macOS [version]

## Checklist

- [x] This PR was discussed with the maintainer either via GitHub issue or other means (Also check if this PR is small enough not to need discussion e.g. typo fix)
- [x] I have read `CONTRIBUTING.md`
- [ ] Testing steps are documented above.
- [x] This change is not low effort and I took the time to test it
